### PR TITLE
Pass event object to handleDOMEvent handler

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -20,7 +20,7 @@ function initInput(view) {
   for (let event in handlers) {
     let handler = handlers[event]
     view.content.addEventListener(event, e => {
-      if (!view.someProp("handleDOMEvent", f => f(view, event)))
+      if (!view.someProp("handleDOMEvent", f => f(view, e)))
         handler(view, e)
     })
   }


### PR DESCRIPTION
The signature in the docs for `handleDOMEvent` is:

```js
handleDOMEvent:: ?(view: EditorView, event: dom.Event) → bool
```

Currently an event object is not actually being passed as the second argument. Instead, the event name (string type) is being passed. This PR brings the implementation into agreement with the docs.