### PR TITLE
Fix focusing via editorView.focus() in Firefox

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -94,7 +94,7 @@ function selectionToDOM(view, sel, takeFocus) {
   if (!view.hasFocus()) {
     if (!takeFocus) return
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=921444
-    else if (browser.gecko) this.view.content.focus()
+    else if (browser.gecko) view.content.focus()
   }
 
   if (sel instanceof NodeSelection)


### PR DESCRIPTION
It doesn't work currently because when you call editorView.focus(), it goes through `EditorView.focus() -> selectionToDOM()`, and there it tries to call `this.view.content.focus()`. `this` in that context is `Window`, and it doesn't have the `view` property. When I change it to just `view.content.focus()`, it seems like it fixes the issue in Firefox.