### PR TITLE
Protect against global navigator and document

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,10 +1,11 @@
-const ie_upto10 = /MSIE \d/.test(navigator.userAgent)
-const ie_11up = /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(navigator.userAgent)
+const has_navigator = typeof navigator != "undefined"
+const ie_upto10 = has_navigator ? /MSIE \d/.test(navigator.userAgent) : false
+const ie_11up = has_navigator ? /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(navigator.userAgent) : false
 
 module.exports = {
-  mac: /Mac/.test(navigator.platform),
+  mac: has_navigator ? /Mac/.test(navigator.platform) : false,
   ie: ie_upto10 || !!ie_11up,
-  ie_version: ie_upto10 ? document.documentMode || 6 : ie_11up && +ie_11up[1],
-  gecko: /gecko\/\d/i.test(navigator.userAgent),
-  ios: /AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent)
+  ie_version: (ie_upto10 && typeof document != "undefined") ? document.documentMode || 6 : ie_11up && +ie_11up[1],
+  gecko: has_navigator ? /gecko\/\d/i.test(navigator.userAgent) : false,
+  ios: has_navigator ? (/AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent)) : false
 }


### PR DESCRIPTION
The rest of the PM code base protects against these globals that will just blow up in Node, but the guards were missing here.

I've tried to stick to your coding style, LMK if it's not quite what you expect.