### PR TITLE
Remove delay before storing updated selection

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -31,7 +31,7 @@ class SelectionReader {
 
   startPolling(origin) {
     clearTimeout(this.polling)
-    this.polling = setTimeout(origin ? () => this.pollFunc(origin) : this.poller, 50)
+    this.polling = setTimeout(origin ? () => this.pollFunc(origin) : this.poller, 0)
   }
 
   fastPoll(origin) {


### PR DESCRIPTION
We started using ProseMirror in a collaborative environment and found quite a major issue with cursor re-positioning when receiving changes from peers.

Here is a little video showing two windows, the latter which programatically types in text at a realistic pace. Pay attention to the uppermost window, where the only thing done is pressing the ➡️  key, first a couple times per second during a few seconds, then holding it non-stop for a few more seconds.

![selection-before](https://cloud.githubusercontent.com/assets/166943/20576051/1dfda174-b18a-11e6-834b-3373a448b4d3.gif)

You can see the cursor is often moved back to its previous position, and when the ➡️  key is held down it feels really buggish. The following explains the cause and solution to this problem.

Upon receiving a peer transform, ProseMirror applies the transform (which re-maps selection) based on the _last stored selection_. This is OK. The problem is _when_ the selection is actually stored into the state. Key and mouse events call the `SelectionReader#fastPoll` function instantaneously on each event, which then calls `startPolling`. However `startPolling` currently delays storing the selection by 50ms every time it is called.

This can be clearly illustrated by logging `selection`-type actions received by `onAction`:

```diff
 var view = window.view = new EditorView(document.querySelector(".full"), {
   state: state,
   onAction: function(action) {
+    if (action.type == "selection") {
+      console.log("selection change")
+    }
     view.updateState(view.state.applyAction(action))
   },
 })
```
![selection-change-log](https://cloud.githubusercontent.com/assets/166943/20575735/8915f60c-b188-11e6-8bb2-dd1c46c570f8.gif)

When I hold the ➡️  key, every call to `startPolling` clears the previous timeout and starts a new one with a 50ms delay, thus never storing the selection until I release the key for at least 50ms.

I changed the 50ms delay to 0ms, which ensures an updated selection is stored after every keystroke. This eliminates any cursor re-mapping issue during collaborative editing (if you see some lag, it’s a .gif lag):

![selection-after](https://cloud.githubusercontent.com/assets/166943/20576449/026757dc-b18c-11e6-9d26-1d2b5a8d69d6.gif)
