### PR TITLE
Ensure selection is definitely collapsed - fixes Blink Shadow DOM bug

### DIFF
--- a/src/domchange.js
+++ b/src/domchange.js
@@ -3,7 +3,7 @@ const {Selection} = require("prosemirror-state")
 const {Mapping} = require("prosemirror-transform")
 
 const {TrackMappings} = require("./trackmappings")
-const {selectionBetween} = require("./selection")
+const {selectionBetween, selectionCollapsed} = require("./selection")
 
 class DOMChange {
   constructor(view, composing) {
@@ -109,7 +109,7 @@ function parseBetween(view, oldState, range) {
   let domSel = view.root.getSelection(), find = null, anchor = domSel.anchorNode
   if (anchor && view.dom.contains(anchor.nodeType == 1 ? anchor : anchor.parentNode)) {
     find = [{node: anchor, offset: domSel.anchorOffset}]
-    if (!domSel.isCollapsed)
+    if (!selectionCollapsed(domSel))
       find.push({node: domSel.focusNode, offset: domSel.focusOffset})
   }
   let startDoc = oldState.doc

--- a/src/selection.js
+++ b/src/selection.js
@@ -67,7 +67,7 @@ class SelectionReader {
     }
     let head = this.view.docView.posFromDOM(domSel.focusNode, domSel.focusOffset)
     let $head = doc.resolve(head), $anchor, selection
-    if (domSel.isCollapsed) {
+    if (selectionCollapsed(domSel)) {
       $anchor = $head
       while (nearestDesc && !nearestDesc.node) nearestDesc = nearestDesc.parent
       if (nearestDesc && nearestDesc.node.isAtom && NodeSelection.isSelectable(nearestDesc.node)) {
@@ -219,6 +219,21 @@ function temporarilyEditable(view, pos) {
     return desc.dom
   }
 }
+
+function selectionCollapsed(selection) {
+  if (!selection.isCollapsed) {
+    return false
+  }
+
+  for (let i = 0, k = selection.rangeCount; i < k; i++) {
+    if (!selection.getRangeAt(i).collapsed) {
+      return false
+    }
+  }
+
+  return true
+}
+exports.selectionCollapsed = selectionCollapsed
 
 function removeClassOnSelectionChange(view) {
   document.removeEventListener("selectionchange", view.hideSelectionGuard)


### PR DESCRIPTION
This checks that a selection's ranges are all collapsed instead of just relying on the `isCollapsed` property. This can occur in both v0 and v1 Shadow DOM implementations in Chrome - see [this Blink bug](https://bugs.chromium.org/p/chromium/issues/detail?id=447523).

Fixes [this issue](https://github.com/ProseMirror/prosemirror/issues/588)