### PR TITLE
Check for rangeCount and anchorNode in selection check

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -282,5 +282,5 @@ exports.selectionBetween = selectionBetween
 function hasFocusAndSelection(view) {
   if (view.editable && view.root.activeElement != view.dom) return false
   let sel = view.root.getSelection()
-  return sel.rangeCount && view.dom.contains(sel.anchorNode.nodeType == 3 ? sel.anchorNode.parentNode : sel.anchorNode)
+  return sel.rangeCount && sel.anchorNode && view.dom.contains(sel.anchorNode.nodeType == 3 ? sel.anchorNode.parentNode : sel.anchorNode)
 }

--- a/src/selection.js
+++ b/src/selection.js
@@ -282,5 +282,5 @@ exports.selectionBetween = selectionBetween
 function hasFocusAndSelection(view) {
   if (view.editable && view.root.activeElement != view.dom) return false
   let sel = view.root.getSelection()
-  return sel.rangeCount && sel.anchorNode && view.dom.contains(sel.anchorNode.nodeType == 3 ? sel.anchorNode.parentNode : sel.anchorNode)
+  return sel.anchorNode && view.dom.contains(sel.anchorNode.nodeType == 3 ? sel.anchorNode.parentNode : sel.anchorNode)
 }


### PR DESCRIPTION
Adds a check in `hasFocusAndSelection` to check if the selection has an `anchorNode` as well as `rangeCount` > 0

This fixes https://github.com/ProseMirror/prosemirror/issues/614 where Shadow DOM in Chrome 57 incorrectly reports the selection as still having a range even when there's no selection and therefore no `anchorNode`.