### PR TITLE
Add chrome browser check

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -11,4 +11,5 @@ if (typeof navigator != "undefined") {
   result.gecko = !ie && /gecko\/\d/i.test(navigator.userAgent)
   result.ios = !ie && /AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent)
   result.webkit = !ie && 'WebkitAppearance' in document.documentElement.style
+  result.chrome = !ie && /Chrome/.test(navigator.userAgent)
 }


### PR DESCRIPTION
Adds in a `chrome` property to the browsers file. This allows the selection bug [check](https://github.com/ProseMirror/prosemirror-view/blob/master/src/dom.js#L60) which was added to fix [Shadow DOM failing in chrome](https://github.com/ProseMirror/prosemirror/issues/588)