### PR TITLE
Allow the DOMChange timeout to be customized

### DIFF
--- a/src/domchange.js
+++ b/src/domchange.js
@@ -12,7 +12,7 @@ class DOMChange {
     this.state = view.state
     this.composing = composing
     this.from = this.to = null
-    this.timeout = composing ? null : setTimeout(() => this.finish(), 20)
+    this.timeout = composing ? null : setTimeout(() => this.finish(), DOMChange.commitTimeout)
     this.trackMappings = new TrackMappings(view.state)
 
     // If there have been changes since this DOM update started, we must
@@ -97,6 +97,7 @@ class DOMChange {
     return view.inDOMChange
   }
 }
+DOMChange.commitTimeout = 20
 exports.DOMChange = DOMChange
 
 // Note that all referencing and parsing is done with the


### PR DESCRIPTION
This 20ms timeout is to fix issues with Android Chrome, but it makes a
jitter in the editor when plugins cancel/modify user input.

This change allows the implementor to change the timeout. This may be
done statically if Android is not a supported platform, or the
implementor may use means to detect the platform and change the timeout
based on that.

This may be a stop-gap until someone can find time to do some hard testing on Android for a better solution.