### PR TITLE
Add coordsAtRange

### DIFF
--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -238,6 +238,21 @@ function coordsAtPos(view, pos) {
 }
 exports.coordsAtPos = coordsAtPos
 
+// : (EditorView, number, number) → {left: number, top: number, right: number, bottom: number}
+// Given a range in the document model, get a bounding box of the
+// entire range, relative to the window.
+function coordsAtRange(view, from, to) {
+  if (from === to) return coordsAtPos(view, from)
+  let {node: fromNode, offset: fromOffset} = view.docView.domFromPos(from)
+  let {node: toNode, offset: toOffset} = view.docView.domFromPos(to)
+  let range = document.createRange()
+  range.setStart(fromNode, fromOffset)
+  range.setEnd(toNode, toOffset)
+  let rect = range.getBoundingClientRect()
+  return {left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom}
+}
+exports.coordsAtRange = coordsAtRange
+
 function withFlushedState(view, state, f) {
   let viewState = view.state, active = view.root.activeElement
   if (viewState != state || !view.inDOMChange) view.updateState(state)

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 const {Mark} = require("prosemirror-model")
 const {NodeSelection} = require("prosemirror-state")
 
-const {scrollRectIntoView, posAtCoords, coordsAtPos, endOfTextblock, storeScrollPos, resetScrollPos} = require("./domcoords")
+const {scrollRectIntoView, posAtCoords, coordsAtPos, coordsAtRange, endOfTextblock,
+  storeScrollPos, resetScrollPos} = require("./domcoords")
 const {docViewDesc} = require("./viewdesc")
 const {initInput, destroyInput, dispatchEvent, ensureListeners} = require("./input")
 const {SelectionReader, selectionToDOM} = require("./selection")
@@ -223,6 +224,16 @@ class EditorView {
     if (this.inDOMChange)
       pos = this.inDOMChange.mapping.invert().map(pos)
     return coordsAtPos(this, pos)
+  }
+
+  // :: (number, number) → {left: number, right: number, top: number, bottom: number}
+  // Returns the screen rectangle at a given document range.
+  coordsAtRange(from, to) {
+    if (this.inDOMChange) {
+      from = this.inDOMChange.mapping.invert().map(from)
+      to = this.inDOMChange.mapping.invert().map(to)
+    }
+    return coordsAtRange(this, from, to)
   }
 
   // :: (union<"up", "down", "left", "right", "forward", "backward">, ?EditorState) → bool


### PR DESCRIPTION
Provide helper to get coordinates for the given range. This unlocks
floating menu plugins to display over selected text.