### PR TITLE
Fix wrong node match during sync

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -542,7 +542,7 @@ class NodeViewDesc extends ViewDesc {
   }
 
   matchesNode(node, outerDeco, innerDeco) {
-    return this.dirty == NOT_DIRTY && node.eq(this.node) &&
+    return this.dirty == NOT_DIRTY && node == this.node &&
       sameOuterDeco(outerDeco, this.outerDeco) && innerDeco.eq(this.innerDeco)
   }
 


### PR DESCRIPTION
Consider the following document:
```
Content 1
[selection]
[Very big node with lots of nested nodes]
x
```
If I type `x` in place of `[selection]`. Then during `findNodeMatch` it will match the new node with the last `x` (since `content` & `marks` same) and remove `[Very big node with lots of nested nodes]` and recreate it afterward.

Same thing happens for new lines too. Though the end result is same. But for very big documents it has performance implications.