### PR TITLE
Fix explosion on creating editor when editable returns false.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,9 @@ class EditorView {
     this.docView = docViewDesc(this.state.doc, computeDocDeco(this), viewDecorations(this), this.dom, this)
 
     this.lastSelectedViewDesc = null
+    initInput(this) // Must be done before creating a SelectionReader
+
     this.selectionReader = new SelectionReader(this)
-    initInput(this)
 
     this.pluginViews = []
     this.updatePluginViews()


### PR DESCRIPTION
The SelectionReader is created in the EditorView constructor before calling 'initInput'.

If the view isn't editable, this starts a poller to keep the selection in sync with the DOM, which ends up calling `this.view.domObserver.flush()`.

Since the `domObserver` gets created by initInput, which hasn't been called yet, this doesn't exist and explodes.

I'm not quite sure why my usage is triggering this bug, I assume other people's isn't? I'm rendering this editor output on a tooltip which is getting moved about, so perhaps it's something to do with that - regardless, this seems like a clear bug to me. Creating the `domObserver` before the `SelectionReader` appears to fix it.

Note that the SelectionReader can also generate a transaction before init returns, which I'm not sure if is considered a problem in ProseMirror.

Alternatively it may be better to disable the selection api while the editor isn't editable?