### PR TITLE
Make Decoration.from and Decoration.to public API

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -91,7 +91,9 @@ class NodeType {
 // static members of this class for details.
 class Decoration {
   constructor(from, to, type) {
+    // :: number
     this.from = from
+    // :: number
     this.to = to
     this.type = type
   }


### PR DESCRIPTION
I propose making `from` an `to` public API, to open up some new possibilities with decorations.

My use-case is having decorations that can be either 'active' or 'inactive'. An example is inline comments use inline decorations to highlight text, and use different colors depending on whether or not that specific comment is being viewed (e.g. in the document's sidebar).

Given a decoration, it's not currently possible to create a new decoration over the same range (since `from` and `to` are not exposed).