### PR TITLE
Fix wrapMap content order

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -125,8 +125,8 @@ function closeRight(node, depth) {
 // Trick from jQuery -- some elements must be wrapped in other
 // elements for innerHTML to work. I.e. if you do `div.innerHTML =
 // "<td>..</td>"` the table cells are ignored.
-const wrapMap = {thead: ["table"], colgroup: ["table"], col: ["table", "colgroup"],
-                 tr: ["table", "tbody"], td: ["table", "tbody", "tr"], th: ["table", "tbody", "tr"]}
+const wrapMap = {thead: ["table"], colgroup: ["table"], col: ["colgroup", "table"],
+                 tr: ["tbody" ,"table"], td: ["tr", "tbody", "table"], th: ["tr", "tbody", "table"]}
 let detachedDoc = null
 function readHTML(html) {
   let metas = /(\s*<meta [^>]*>)*/.exec(html)


### PR DESCRIPTION
When I copy the **tr** node in the editor, then it give me` <tbody><table><tr>....</tr></table></tbody>  `

I find out serializeForClipboard function will wrap the wrapMap content **sequentially** if the nodeName is in the wrapMap.

For example, the "tr" key map to wapMap is `['table', 'tbody']` , so serializeForClipboard will wrap the "tr" node around the "table" node first, then wrap around the "tbody" node.

So I reverse the wrapMap content to fix this issue.