### PR TITLE
Show text cursor over text in list items

### DIFF
--- a/style/prosemirror.css
+++ b/style/prosemirror.css
@@ -13,6 +13,10 @@
   cursor: default;
 }
 
+.ProseMirror li > * {
+  cursor: auto;
+}
+
 .ProseMirror pre {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
FIX: Show text cursor, not pointer, over text in list items.