### PR TITLE
Be less strict to find out if view has focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ export class EditorView {
   // :: () → bool
   // Query whether the view has focus.
   hasFocus() {
-    return this.root.activeElement == this.dom
+    return this.dom.contains(this.root.activeElement)
   }
 
   // :: ()

--- a/src/selection.js
+++ b/src/selection.js
@@ -287,7 +287,7 @@ export function selectionBetween(view, $anchor, $head, bias) {
 }
 
 function hasFocusAndSelection(view) {
-  if (view.editable && view.root.activeElement != view.dom) return false
+  if (view.editable && !view.hasFocus()) return false
   let sel = view.root.getSelection()
   if (!sel.anchorNode) return false
   try {


### PR DESCRIPTION
This allows client code to workaround https://github.com/ProseMirror/prosemirror/issues/745