### PR TITLE
Allow markview to specify a contentDOM element

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -464,7 +464,9 @@ class MarkViewDesc extends ViewDesc {
     let custom = customNodeViews(view)[mark.type.name]
     let spec = custom && custom(mark, view)
     let dom = spec && spec.dom || DOMSerializer.renderSpec(document, mark.type.spec.toDOM(mark, inline)).dom
-    return new MarkViewDesc(parent, mark, dom)
+    let markDesc = new MarkViewDesc(parent, mark, dom)
+    if (spec && spec.contentDOM) markDesc.contentDOM = spec.contentDOM
+    return markDesc
   }
 
   parseRule() { return {mark: this.mark.type.name, attrs: this.mark.attrs, contentElement: this.contentDOM} }


### PR DESCRIPTION
Use case: Use a markview to render hyperlink as a preview of the content
it links to for certain content types, e.g. a video thumbnail.
Otherwise allow prosemirror to manage hyperlinked text using contentDOM.