### PR TITLE
support for nodes those not under document.body

### DIFF
--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -10,7 +10,7 @@ export function scrollRectIntoView(view, rect) {
   let doc = view.dom.ownerDocument, win = doc.defaultView
   if (scrollMargin == null) scrollMargin = 5
   for (let parent = view.dom;; parent = parentNode(parent)) {
-    if (!parent) break
+    if (!parent || parent === document) break
     let atBody = parent == doc.body
     let bounding = atBody ? windowRect(win) : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0

--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -10,7 +10,7 @@ export function scrollRectIntoView(view, rect) {
   let doc = view.dom.ownerDocument, win = doc.defaultView
   if (scrollMargin == null) scrollMargin = 5
   for (let parent = view.dom;; parent = parentNode(parent)) {
-    if (!parent || parent === document) break
+    if (!parent || parent.nodeType != 1) break
     let atBody = parent == doc.body
     let bounding = atBody ? windowRect(win) : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0


### PR DESCRIPTION
Hey guys,

when EditorView.updateState called, scrollRectIntoView() raising following error:
![image](https://user-images.githubusercontent.com/20118952/42126225-566c2722-7c8d-11e8-93a1-e69c272bbc6d.png)

As I've seen the issue is caused that our editor is not under document.body. 
![image](https://user-images.githubusercontent.com/20118952/42126204-f217feea-7c8c-11e8-95e7-1dcc234f2cf9.png)

A quick fix is to break scroll loop if parent is document itself. 

We are excited to use this editor, can you please add support for such a case.
