### PR TITLE
Add ability to run any kind of transaction during init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,9 @@ export class EditorView {
     this._root = null
     this.focused = false
 
+    this.initialized = false;
+    this.transactionQueue = [];
+
     // :: dom.Element
     // An editable DOM node containing the document. (You probably
     // should not directly interfere with its content.)
@@ -61,6 +64,7 @@ export class EditorView {
 
     this.pluginViews = []
     this.updatePluginViews()
+    this.runTransactionQueue()
   }
 
   // :: DirectEditorProps
@@ -330,8 +334,18 @@ export class EditorView {
   // easily passed around.
   dispatch(tr) {
     let dispatchTransaction = this._props.dispatchTransaction
+    if (!this.initialized) {
+      this.transactionQueue.push(tr)
+      return
+    }
     if (dispatchTransaction) dispatchTransaction.call(this, tr)
     else this.updateState(this.state.apply(tr))
+  }
+
+  runTransactionQueue() {
+    this.initialized = true
+    this.transactionQueue.forEach(this.dispatch)
+    this.transactionQueue = []
   }
 }
 

--- a/test/test-view.js
+++ b/test/test-view.js
@@ -1,5 +1,5 @@
 const {schema, doc, ul, li, p, strong, hr} = require("prosemirror-test-builder")
-const {EditorState} = require("prosemirror-state")
+const {EditorState, Plugin} = require("prosemirror-state")
 const {Schema} = require("prosemirror-model")
 const {EditorView} = require("../dist")
 const {tempEditor} = require("./view")
@@ -95,5 +95,26 @@ describe("EditorView", () => {
     })
     view.dispatch(view.state.tr.insertText("x"))
     ist(view, thisBinding)
+  })
+
+  it("allows node views to dispatch transactions during init", () => {
+    const dom = document.createElement("div");
+    let thisBinding;
+    let view = new EditorView(dom, {
+      state: EditorState.create({
+        doc: doc(p("a")),
+        plugins: [new Plugin({
+          props: {
+            nodeViews: {
+              paragraph: (node, view) => {
+                view.dispatch(view.state.tr.insertText("x"));
+                return {};
+              }
+            }
+          }
+        })]
+      })
+    })
+    ist(view.state.doc.eq(doc(p("xa"))), true)
   })
 })


### PR DESCRIPTION
With my last PR it allowed me to run some transactions (specifically regarding node views). This should add the ability to run any transactions that can be run against an unfocussed view by just queuing them until init is complete.