### PR TITLE
Add a few enhancements to scroll behaviors

### DIFF
--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -6,22 +6,27 @@ function windowRect(win) {
 }
 
 export function scrollRectIntoView(view, rect) {
-  let scrollThreshold = view.someProp("scrollThreshold") || 0, scrollMargin = view.someProp("scrollMargin")
+  let scrollThreshold = view.someProp("scrollThreshold") || 0, scrollMargin = view.someProp("scrollMargin") || 5
+  if (Number.isInteger(scrollThreshold))
+    scrollThreshold = {top: scrollThreshold, right: scrollThreshold, bottom: scrollThreshold, left: scrollThreshold}
+  if (Number.isInteger(scrollMargin))
+    scrollMargin = {top: scrollMargin, right: scrollMargin, bottom: scrollMargin, left: scrollMargin}
+
   let doc = view.dom.ownerDocument, win = doc.defaultView
-  if (scrollMargin == null) scrollMargin = 5
-  for (let parent = view.dom;; parent = parentNode(parent)) {
+  let ref = parentNode(view.docView.domFromPos(view.state.selection.head).node)
+  for (let parent = ref;; parent = parentNode(parent)) {
     if (!parent) break
     let atTop = parent == doc.body || parent.nodeType != 1
     let bounding = atTop ? windowRect(win) : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0
-    if (rect.top < bounding.top + scrollThreshold)
-      moveY = -(bounding.top - rect.top + scrollMargin)
-    else if (rect.bottom > bounding.bottom - scrollThreshold)
-      moveY = rect.bottom - bounding.bottom + scrollMargin
-    if (rect.left < bounding.left + scrollThreshold)
-      moveX = -(bounding.left - rect.left + scrollMargin)
-    else if (rect.right > bounding.right - scrollThreshold)
-      moveX = rect.right - bounding.right + scrollMargin
+    if (rect.top < bounding.top + scrollThreshold.top)
+      moveY = -(bounding.top - rect.top + scrollMargin.top)
+    else if (rect.bottom > bounding.bottom - scrollThreshold.bottom)
+      moveY = rect.bottom - bounding.bottom + scrollMargin.bottom
+    if (rect.left < bounding.left + scrollThreshold.left)
+      moveX = -(bounding.left - rect.left + scrollMargin.left)
+    else if (rect.right > bounding.right - scrollThreshold.right)
+      moveX = rect.right - bounding.right + scrollMargin.right
     if (moveX || moveY) {
       if (atTop) {
         win.scrollBy(moveX, moveY)

--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -5,13 +5,12 @@ function windowRect(win) {
           top: 0, bottom: win.innerHeight}
 }
 
+function getSide(value, side) {
+  return typeof value == "number" ? value : value[side]
+}
+
 export function scrollRectIntoView(view, rect) {
   let scrollThreshold = view.someProp("scrollThreshold") || 0, scrollMargin = view.someProp("scrollMargin") || 5
-  if (Number.isInteger(scrollThreshold))
-    scrollThreshold = {top: scrollThreshold, right: scrollThreshold, bottom: scrollThreshold, left: scrollThreshold}
-  if (Number.isInteger(scrollMargin))
-    scrollMargin = {top: scrollMargin, right: scrollMargin, bottom: scrollMargin, left: scrollMargin}
-
   let doc = view.dom.ownerDocument, win = doc.defaultView
   let ref = parentNode(view.docView.domFromPos(view.state.selection.head).node)
   for (let parent = ref;; parent = parentNode(parent)) {
@@ -19,14 +18,14 @@ export function scrollRectIntoView(view, rect) {
     let atTop = parent == doc.body || parent.nodeType != 1
     let bounding = atTop ? windowRect(win) : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0
-    if (rect.top < bounding.top + scrollThreshold.top)
-      moveY = -(bounding.top - rect.top + scrollMargin.top)
-    else if (rect.bottom > bounding.bottom - scrollThreshold.bottom)
-      moveY = rect.bottom - bounding.bottom + scrollMargin.bottom
-    if (rect.left < bounding.left + scrollThreshold.left)
-      moveX = -(bounding.left - rect.left + scrollMargin.left)
-    else if (rect.right > bounding.right - scrollThreshold.right)
-      moveX = rect.right - bounding.right + scrollMargin.right
+    if (rect.top < bounding.top + getSide(scrollThreshold, "top"))
+      moveY = -(bounding.top - rect.top + getSide(scrollMargin, "top"))
+    else if (rect.bottom > bounding.bottom - getSide(scrollThreshold, "bottom"))
+      moveY = rect.bottom - bounding.bottom + getSide(scrollMargin, "bottom")
+    if (rect.left < bounding.left + getSide(scrollThreshold, "left"))
+      moveX = -(bounding.left - rect.left + getSide(scrollMargin, "left"))
+    else if (rect.right > bounding.right - getSide(scrollThreshold, "right"))
+      moveX = rect.right - bounding.right + getSide(scrollMargin, "right")
     if (moveX || moveY) {
       if (atTop) {
         win.scrollBy(moveX, moveY)

--- a/src/index.js
+++ b/src/index.js
@@ -141,16 +141,7 @@ export class EditorView {
         {} // Handled
       else if (state.selection instanceof NodeSelection)
         scrollRectIntoView(this, this.docView.domAfterPos(state.selection.from).getBoundingClientRect())
-      else if (state.selection.from != state.selection.to) {
-        const fromCoords = this.coordsAtPos(state.selection.from);
-        const toCoords = this.coordsAtPos(state.selection.to);
-        scrollRectIntoView(this, {
-          top: fromCoords.top,
-          bottom: toCoords.bottom,
-          left: fromCoords.left,
-          right: toCoords.right
-        });
-      } else
+      else
         scrollRectIntoView(this, this.coordsAtPos(state.selection.head))
     } else if (oldScrollPos) {
       resetScrollPos(oldScrollPos)

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,16 @@ export class EditorView {
         {} // Handled
       else if (state.selection instanceof NodeSelection)
         scrollRectIntoView(this, this.docView.domAfterPos(state.selection.from).getBoundingClientRect())
-      else
+      else if (state.selection.from != state.selection.to) {
+        const fromCoords = this.coordsAtPos(state.selection.from);
+        const toCoords = this.coordsAtPos(state.selection.to);
+        scrollRectIntoView(this, {
+          top: fromCoords.top,
+          bottom: toCoords.bottom,
+          left: fromCoords.left,
+          right: toCoords.right
+        });
+      } else
         scrollRectIntoView(this, this.coordsAtPos(state.selection.head))
     } else if (oldScrollPos) {
       resetScrollPos(oldScrollPos)
@@ -540,12 +549,12 @@ function getEditable(view) {
 //   the value provided first (as in
 //   [`someProp`](#view.EditorView.someProp)) will be used.
 //
-//   scrollThreshold:: ?number
+//   scrollThreshold:: ?number | {top: number, right: number, bottom: number, left: number}
 //   Determines the distance (in pixels) between the cursor and the
 //   end of the visible viewport at which point, when scrolling the
 //   cursor into view, scrolling takes place. Defaults to 0.
 //
-//   scrollMargin:: ?number
+//   scrollMargin:: ?number | {top: number, right: number, bottom: number, left: number}
 //   Determines the extra space (in pixels) that is left above or
 //   below the cursor when it is scrolled into view. Defaults to 5.
 


### PR DESCRIPTION
1. Allow `scrollThreshold` and `scrollMargin` to be side specific (top,
right, bottom, left).
2. Start scrolling from position of `selection.head` AND NOT `view.dom`. This
way nodes that have internal scrolling (usually horizontal) can get
scrolled (useful for tables).
3. Try to scroll entire selection into view. This way tabbing within a table, which highlights the cell contents, will scroll the entire cell instead of just one side.

I needed 1 in order to differentiate top/bottom vs left/right AND I've got an absolute positioned toolbar that sits above the top part of my editor, thus I need a `scrollThreshold.top` to be greater than `scrollThreshold.bottom`.

Here's what 2 and 3 enable:
![sep-25-2018 23-52-13](https://user-images.githubusercontent.com/1568246/46056347-2cd2eb00-c11e-11e8-9850-9f860c864eb5.gif)

Happy to make any changes requested, would love to see this merged in to prevent necessitating the use of my own fork :) 

