### PR TITLE
Always sync node selections on update state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,7 @@ export class EditorView {
       if (forceSelUpdate ||
           !(this.mouseDown && this.selectionReader.domChanged() && anchorInRightPlace(this)))
         selectionToDOM(this, false, forceSelUpdate)
+      else syncNodeSelection(this, state.selection)
       this.domObserver.start()
     }
 


### PR DESCRIPTION
I'm not sure if this is the best approach but I figured I would make an attempt. We are seeing issues on Prosemirror-view 1.8.2 and 1.8.3 when deselecting node views. Recent commits stopped calling selectionToDOM when clicking off of a node view because `this.mouseDown && this.selectionReader.domChanged() && anchorInRightPlace(this)` is returning true. Although the selection is in the right place, the node selection sync does not happen which makes our node views keep their selected styles.