### PR TITLE
Updated nodeViews delivered by plugins are ignored. 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,14 @@ export class EditorView {
   updateState(state) {
     let prev = this.state
     this.state = state
-    if (prev.plugins != state.plugins) ensureListeners(this)
+    if (prev.plugins != state.plugins) {
+      let nodeViews = buildNodeViews(this)
+      if (changedNodeViews(nodeViews, this.nodeViews)) {
+        this.nodeViews = nodeViews
+        this.redraw = true
+      }
+      ensureListeners(this)
+    }
 
     this.domObserver.flush()
     if (this.inDOMChange && this.inDOMChange.stateUpdated(state)) return


### PR DESCRIPTION
When view state is updated with plugins that expose new `nodeViews` props, the view does not detect the new `nodeViews` and they are ignored.  Also, when using `view.update` or `view.setProps`, they are also ignored.  The reason is because `EditorView.prototype.update` has some code to detect new `nodeViews` props, but since the comparison of old to new `nodeViews` is done before the state is updated, the new plugins are ignored.  

I propose the code below to detect updated `nodeViews` when the state plugins are changed.  I don't foresee performance problems because changing state plugins is infrequent.