### PR TITLE
parseRange: fix empty viewDesc from/to offsets

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -267,7 +267,7 @@ class ViewDesc {
   // range.
   parseRange(from, to, base = 0) {
     if (this.children.length == 0)
-      return {node: this.contentDOM, from, to, fromOffset: 0, toOffset: this.contentDOM.childNodes.length}
+      return {node: this.contentDOM, from + base, to + base, fromOffset: 0, toOffset: this.contentDOM.childNodes.length}
 
     let fromOffset = -1, toOffset = -1
     for (let offset = 0, i = 0;; i++) {


### PR DESCRIPTION
This is a wild guess - it fixes some issues i have had with DOMObserver, like when i insert DOM nodes in an empty contentDOM of a nodeView.
The same issue (not re-adding base to from/to) might still be present in parseRange, in other cases.