### PR TITLE
WIP: Allow NodeViewDesc to ignore selection mutations

### DIFF
--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -84,10 +84,12 @@ export class DOMObserver {
 
   ignoreSelectionMutation(sel) {
     let desc = this.view.docView.nearestDesc(sel.anchorNode, true)
+    
+    if (!desc || !desc.node || !desc.dom) return false
 
     if (desc.node.isText) return false
 
-    return desc && desc.dom && desc.ignoreMutation({
+    return desc.ignoreMutation({
       type: 'selection',
       target: desc.dom
     })

--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -82,17 +82,11 @@ export class DOMObserver {
     this.currentSelection.set(this.view.root.getSelection())
   }
 
-  ignoreSelectionMutation(sel) {
-    let desc = this.view.docView.nearestDesc(sel.anchorNode, true)
-    
-    if (!desc || !desc.node || !desc.dom) return false
+  ignoreSelectionChange(sel) {
+    let container = sel.getRangeAt(0).commonAncestorContainer
+    let desc = this.view.docView.nearestDesc(container, true)
 
-    if (desc.node.isText) return false
-
-    return desc.ignoreMutation({
-      type: 'selection',
-      target: desc.dom
-    })
+    return desc && desc.node && !desc.node.isText && desc.node.isAtom
   }
 
   flush(mutations) {
@@ -105,7 +99,7 @@ export class DOMObserver {
 
     let sel = this.view.root.getSelection()
 
-    let newSel = !this.suppressingSelectionUpdates && !this.currentSelection.eq(sel) && hasSelection(this.view) && !this.ignoreSelectionMutation(sel)
+    let newSel = !this.suppressingSelectionUpdates && !this.currentSelection.eq(sel) && hasSelection(this.view) && !this.ignoreSelectionChange(sel)
 
     let from = -1, to = -1, typeOver = false
     if (this.view.editable) {

--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -82,6 +82,15 @@ export class DOMObserver {
     this.currentSelection.set(this.view.root.getSelection())
   }
 
+  ignoreSelectionMutation(sel) {
+    let desc = this.view.docView.nearestDesc(sel.anchorNode, true)
+
+    return desc && desc.dom && desc.ignoreMutation({
+      type: 'selection',
+      target: desc.dom
+    })
+  }
+
   flush(mutations) {
     if (!this.view.docView) return
     if (!mutations) mutations = this.observer.takeRecords()
@@ -91,7 +100,8 @@ export class DOMObserver {
     }
 
     let sel = this.view.root.getSelection()
-    let newSel = !this.suppressingSelectionUpdates && !this.currentSelection.eq(sel) && hasSelection(this.view)
+
+    let newSel = !this.suppressingSelectionUpdates && !this.currentSelection.eq(sel) && hasSelection(this.view) && !this.ignoreSelectionMutation(sel)
 
     let from = -1, to = -1, typeOver = false
     if (this.view.editable) {

--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -85,6 +85,8 @@ export class DOMObserver {
   ignoreSelectionMutation(sel) {
     let desc = this.view.docView.nearestDesc(sel.anchorNode, true)
 
+    if (desc.node.isText) return false
+
     return desc && desc.dom && desc.ignoreMutation({
       type: 'selection',
       target: desc.dom


### PR DESCRIPTION
This is an implementation of [RFC 13](https://github.com/ProseMirror/rfcs/pull/13), with some caveats:

* I haven't tried it with anything other than `ignoreMutation = () => true` in a NodeViewDesc, because I didn't need to filter based on the node.
* I'm not yet sure how to write a test for this.