### PR TITLE
Fix eq() comparison of DecorationSets

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -380,7 +380,7 @@ export class DecorationSet {
       if (this.children[i] != other.children[i] ||
           this.children[i + 1] != other.children[i + 1] ||
           !this.children[i + 2].eq(other.children[i + 2])) return false
-    return false
+    return true
   }
 
   locals(node) {


### PR DESCRIPTION
This function is currently always returning false for different objects, so the value equality comparison is not working. Seems like a typo to me, and I think this causes some unnecessary re-renders when applying the same decoration set.