### PR TITLE
Ignoring redundant characterData mutations in Composition view descs 

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -481,7 +481,9 @@ class CompositionViewDesc extends ViewDesc {
     return {node: this.textDOM, offset: pos + (zwsp > -1 && zwsp <= pos ? 1 : 0)}
   }
 
-  ignoreMutation() { return false }
+  ignoreMutation(mut) { 
+    return mut.type === 'characterData' && mut.target.nodeValue == mut.oldValue
+   }
 }
 
 // A mark desc represents a mark. May have multiple children,


### PR DESCRIPTION
Firefox registers an extra mutation record during compositions which causes stored marks to be removed at the end of a composition. Skipping characterData mutations where the value has not changed resolves this.