### PR TITLE
Adding a trackingOnly check on selections before syncing prosemirror selections to the dom

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -47,17 +47,20 @@ export function selectionToDOM(view, takeFocus, force) {
   if (view.cursorWrapper) {
     selectCursorWrapper(view)
   } else {
-    let {anchor, head} = sel, resetEditableFrom, resetEditableTo
-    if (brokenSelectBetweenUneditable && !(sel instanceof TextSelection)) {
-      if (!sel.$from.parent.inlineContent)
-        resetEditableFrom = temporarilyEditableNear(view, sel.from)
-      if (!sel.empty && !sel.$from.parent.inlineContent)
-        resetEditableTo = temporarilyEditableNear(view, sel.to)
-    }
-    view.docView.setSelection(anchor, head, view.root, force)
-    if (brokenSelectBetweenUneditable) {
-      if (resetEditableFrom) resetEditableFrom.contentEditable = "false"
-      if (resetEditableTo) resetEditableTo.contentEditable = "false"
+    let {anchor, head} = sel
+    if(!sel.trackingOnly) {
+      let resetEditableFrom, resetEditableTo
+      if (brokenSelectBetweenUneditable && !(sel instanceof TextSelection)) {
+        if (!sel.$from.parent.inlineContent)
+          resetEditableFrom = temporarilyEditableNear(view, sel.from)
+        if (!sel.empty && !sel.$from.parent.inlineContent)
+          resetEditableTo = temporarilyEditableNear(view, sel.to)
+      }
+      view.docView.setSelection(anchor, head, view.root, force)
+      if (brokenSelectBetweenUneditable) {
+        if (resetEditableFrom) resetEditableFrom.contentEditable = "false"
+        if (resetEditableTo) resetEditableTo.contentEditable = "false"
+      }
     }
     if (sel.visible) {
       view.dom.classList.remove("ProseMirror-hideselection")


### PR DESCRIPTION
If you are ok with this, I can also submit a PR to Prosemirror-state to add this as an actual property on Selections.

What we are trying to do is have a custom selection that is tracked in Prosemirror state but is "hands off" when it comes to the native selection. We have a few NodeViews where we want to give users the ability to select text and interact with the NodeViews in a few different ways. The problem is, what should the Prosemirror selection be when the native selection is inside one of these NodeViews?

We built a new custom selection called NestedSelection and added a selection listener in a plugin. If the selection is inside one of these special containers, we set the NestedSelection in a similar way to how we set NodeSelection. This works just fine after the selection is set, but during the initial setting of NestedSelection, prosemirror-view calls selectionToDOM and overwrites the native selection once we start selecting content.

Since the NodeView is essentially an atom, we don't get access to the `child.setSelection` condition in `ViewDesc.setSelection`. However, if we skip the `docView.setSelection` call in selectionToDOM, everything works beautifully and the interaction appears to be flawless.

So because of this, I'd like to propose a new field that allows selections to be tracked from the native selection, but does not force the prosemirror selection to update the native selection.