### PR TITLE
Add documentation for undocumented parameter on node().

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -176,6 +176,10 @@ export class Decoration {
   // Creates a node decoration. `from` and `to` should point precisely
   // before and after a node in the document. That node, and only that
   // node, will receive the given attributes.
+  //
+  //   spec:: ?Object
+  //   Optional information to store with the decoration. It
+  //   is also used when comparing decorators for equality.
   static node(from, to, attrs, spec) {
     return new Decoration(from, to, new NodeType(attrs, spec))
   }


### PR DESCRIPTION
I hope this is correct, doesn't seem to have any keys with side effects like inline, just used for equality checks.