### PR TITLE
Add a warning when prosemirror.css has not been loaded.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {initInput, destroyInput, dispatchEvent, ensureListeners} from "./input"
 import {selectionToDOM, anchorInRightPlace, syncNodeSelection} from "./selection"
 import {Decoration, viewDecorations} from "./decoration"
 import browser from "./browser"
+import {checkProsemirrorCSSLoaded, checkProsemirrorCSSLoadedOnFocus} from './warn'
 
 export {Decoration, DecorationSet} from "./decoration"
 
@@ -61,6 +62,8 @@ export class EditorView {
     this.dragging = null
 
     initInput(this)
+
+    checkProsemirrorCSSLoadedOnFocus(this)
 
     this.pluginViews = []
     this.updatePluginViews()
@@ -238,6 +241,7 @@ export class EditorView {
       if (this.dom.setActive) this.dom.setActive() // for IE
       else this.dom.focus({preventScroll: true})
     }
+    checkProsemirrorCSSLoaded()
     this.domObserver.start()
   }
 

--- a/src/warn.js
+++ b/src/warn.js
@@ -1,0 +1,25 @@
+let checkedCSS = false
+
+export let checkProsemirrorCSSLoaded = () => {
+  if (!checkedCSS) {
+    checkedCSS = true
+    setTimeout(() => {
+      let div = document.createElement('div')
+      div.className = 'ProseMirror'
+      document.body.appendChild(div)
+      if (getComputedStyle(div).whiteSpace !== 'pre-wrap')
+        console.warn("style/prosemirror.css has not been loaded. ProseMirror may behave incorrectly.")
+      document.body.removeChild(div)
+    }, 1000)
+  }
+}
+
+export let checkProsemirrorCSSLoadedOnFocus = view => {
+  if (!checkedCSS) {
+    let onFirstFocus = () => {
+      checkProsemirrorCSSLoaded()
+      view.dom.removeEventListener('focus', onFirstFocus)
+    }
+    view.dom.addEventListener('focus', onFirstFocus)
+  }
+}


### PR DESCRIPTION
Adds the warning requested in #981.

I'll let you decide whether to merge it. I personally think it's helpful functionality, but
1) it's not easily testable in your unit test framework (because I'd have to mock both console.warn and  the "unloaded" state of prosemirror.css)
2) It requires a custom exception in blint to allow us to use the console. (https://github.com/ProseMirror/prosemirror/pull/987)