### PR TITLE
Tweaking patchAttributes to allow for the removal of css custom properties

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -936,7 +936,7 @@ function patchAttributes(dom, prev, cur) {
     if (prev.style) {
       let prop = /\s*([\w\-\xa1-\uffff]+)\s*:(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\(.*?\)|[^;])*/g, m
       while (m = prop.exec(prev.style))
-        dom.style[m[1].toLowerCase()] = ""
+        dom.style.removeProperty(m[1])
     }
     if (cur.style)
       dom.style.cssText += cur.style

--- a/test/test-composition.js
+++ b/test/test-composition.js
@@ -2,7 +2,7 @@ const {schema, eq, doc, p, em, code, strong} = require("prosemirror-test-builder
 const ist = require("ist")
 const {tempEditor, requireFocus, findTextNode} = require("./view")
 const {Decoration, DecorationSet, __endComposition} = require("..")
-const {Plugin} = require("../../state")
+const {Plugin} = require("prosemirror-state")
 
 // declare global: CompositionEvent
 

--- a/test/test-draw-decoration.js
+++ b/test/test-draw-decoration.js
@@ -278,6 +278,15 @@ describe("Decoration drawing", () => {
     ist(!para.title)
   })
 
+  it("can add and remove CSS custom properties from a node", () => {
+    let deco = Decoration.node(0, 5, {style: '--my-custom-property:36px'})
+    let view = tempEditor({doc: doc(p("foo")),
+                           plugins: [decoPlugin([deco])]})
+    ist(view.dom.querySelector("p").style.getPropertyValue('--my-custom-property'), "36px")
+    updateDeco(view, null, [deco])
+    ist(view.dom.querySelector("p").style.getPropertyValue('--my-custom-property'), "")
+  })
+
   it("updates decorated nodes even if a widget is added before them", () => {
     let view = tempEditor({doc: doc(p("a"), p("b")), plugins: [decoPlugin([])]})
     let lastP = view.dom.querySelectorAll("p")[1]


### PR DESCRIPTION
Using the style setter is not sufficient when dealing with custom properties so this fix uses the CSS Declaration removeProperty instead. Otherwise, styles aren't removed on Node decorations.

Also, tests were not running due to a relative import to Prosemirror-state outside of the repo so I imported from Prosemirror-state directly.