### PR TITLE
Firefox: eliminate bogus BR appeared inside of LI in case of backspacing last character in list item

### DIFF
--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -153,7 +153,7 @@ export class DOMObserver {
     // Firefox adds bogus BR to the very end of LI node
     // in case of backspacing last character in the LI and having inline DOM element in front of it (e.g. SPAN or custom TODO)
     // FF issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1596374
-    if (result.gecko &&
+    if (browser.gecko &&
         mutations.some(mut =>
           mut.target &&
           mut.target.nodeName === "LI" &&

--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -149,6 +149,16 @@ export class DOMObserver {
         }
       }
     }
+
+    // Firefox adds bogus BR to the very end of LI node
+    // in case of backspacing last character in the LI and having inline DOM element in front of it (e.g. SPAN or custom TODO)
+    // FF issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1596374
+    if (result.gecko &&
+        mutations.some(mut =>
+          mut.target.nodeName === "LI" &&
+          mut.addedNodes.length === 1 &&
+          mut.addedNodes[0].nodeName === "BR")) to += 2
+
     if (from > -1 || newSel) {
       if (from > -1) {
         this.view.docView.markDirty(from, to)

--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -155,6 +155,7 @@ export class DOMObserver {
     // FF issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1596374
     if (result.gecko &&
         mutations.some(mut =>
+          mut.target &&
           mut.target.nodeName === "LI" &&
           mut.addedNodes.length === 1 &&
           mut.addedNodes[0].nodeName === "BR")) to += 2


### PR DESCRIPTION
**Prosemirror-view version:** 1.11.2
**FF version:** 69.0.3, 69.0.6, 70.0.1
**FF issue:** https://bugzilla.mozilla.org/show_bug.cgi?id=1596374

**Steps to repro:**
1. Create a list inside the editor each item starts with SPAN or custom Node and have some text after it.
2. Put cursor at the end of any list item.
3. Start delete text until it reaches Node.
4. Observe the result.

**Expected:**
- Last text character deleted and cursor reached DOM element without visible changes in list structure.

**Actual:**
- Blank line after the list item appeared breaking list on to two parts visually.

**NB:**
- This is basically FF issue, and corresponding bug filed there. This PR is to compensate that issue considering it is not clear how long it will take to have a fix on FF side.
- I'm not very familiar with PM, so it might be better way to fix this

**Demo in PM editor:**
![Kapture 2019-11-17 at 14 48 21](https://user-images.githubusercontent.com/1191920/69007055-d04a1500-0949-11ea-966e-2e0596ff4e52.gif)
