### PR TITLE
Not registering style mutations if the value did not change at all

### DIFF
--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -176,8 +176,12 @@ export class DOMObserver {
     let desc = this.view.docView.nearestDesc(mut.target)
     if (mut.type == "attributes" &&
         (desc == this.view.docView || mut.attributeName == "contenteditable" ||
-         // Firefox sometimes fires spurious events for null/empty styles
-         (mut.attributeName == "style" && !mut.oldValue && !mut.target.getAttribute("style"))))
+         (mut.attributeName == "style" && 
+          // Firefox sometimes fires spurious events for null/empty styles
+          (!mut.oldValue && !mut.target.getAttribute("style")) ||
+          // Chrome sometimes fires mutations for styles, even though the value doesn't change at all.
+          // This can cause infinite loops as styles are reparsed
+          mut.oldValue == mut.target.getAttribute("style"))))
       return null
     if (!desc || desc.ignoreMutation(mut)) return null
 


### PR DESCRIPTION
We were seeing infinite loops from our forecolor mark on Chrome because Chrome was registering that the style value had changed, even though it did not. This then triggered our forecolor parse rule which then caused the mark to serialize to dom which then triggered another mutation. This PR skips style mutations if the value doesn't actually at all.