### PR TITLE
wrapMap: add support for tbody, tfoot, caption

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -151,6 +151,9 @@ function closeSlice(slice, openStart, openEnd) {
 // "<td>..</td>"` the table cells are ignored.
 const wrapMap = {
   thead: ["table"],
+  tbody: ["table"],
+  tfoot: ["table"],
+  caption: ["table"],
   colgroup: ["table"],
   col: ["table", "colgroup"],
   tr: ["table", "tbody"],

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -149,8 +149,14 @@ function closeSlice(slice, openStart, openEnd) {
 // Trick from jQuery -- some elements must be wrapped in other
 // elements for innerHTML to work. I.e. if you do `div.innerHTML =
 // "<td>..</td>"` the table cells are ignored.
-const wrapMap = {thead: ["table"], colgroup: ["table"], col: ["table", "colgroup"],
-                 tr: ["table", "tbody"], td: ["table", "tbody", "tr"], th: ["table", "tbody", "tr"]}
+const wrapMap = {
+  thead: ["table"],
+  colgroup: ["table"],
+  col: ["table", "colgroup"],
+  tr: ["table", "tbody"],
+  td: ["table", "tbody", "tr"],
+  th: ["table", "tbody", "tr"]
+}
 
 let _detachedDoc = null
 function detachedDoc() {


### PR DESCRIPTION
This might seem like edge case, but it can happen and it's frustrating to see thead supported but not the other ones.