### PR TITLE
Implement ignoreMutation for Widget Decorations

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -137,6 +137,16 @@ export class Decoration {
   //     Can be used to control which DOM events, when they bubble out
   //     of this widget, the editor view should ignore.
   //
+  //    ignoreMutation:: ?(dom.MutationRecord) → bool
+  //    Called when a DOM
+  //    [mutation](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+  //    or a selection change happens within the Widget. When the change is
+  //    a selection change, the record will have a `type` property of
+  //    `"selection"` (which doesn't occur for native mutation records).
+  //    Return false if the editor should re-read the selection or
+  //    re-parse the range around the mutation, true if it can safely be
+  //    ignored.
+  //
   //     key:: ?string
   //     When comparing decorations of this type (in order to decide
   //     whether it needs to be redrawn), ProseMirror will by default

--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -448,6 +448,10 @@ class WidgetViewDesc extends ViewDesc {
     let stop = this.widget.spec.stopEvent
     return stop ? stop(event) : false
   }
+
+  ignoreMutation(mutation) {
+    return this.widget.spec.ignoreMutation ? this.widget.spec.ignoreMutation(mutation) : super.ignoreMutation(mutation)
+  }
 }
 
 class CompositionViewDesc extends ViewDesc {


### PR DESCRIPTION
We have a widget that can take a selection and the recent change to not ignore selections in the base ViewDesc class has caused a few issues. We have a terrible hack to fix our problem, but I figured I would create this PR because it is an easy extension and this is already being done in CustomNodeViewDesc. If other prosemirror users have a widget that they want to select, this would allow users to ignore selection changes. This would also help make Widgets more future proof if the ViewDesc class continues to change.