### PR TITLE
Fix coordsAtPos after line wrap point

### DIFF
--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -283,16 +283,18 @@ export function coordsAtPos(view, pos) {
   let {node, offset} = view.docView.domFromPos(pos)
 
   // These browsers support querying empty text ranges
-  if (node.nodeType == 3 && (browser.chrome || browser.gecko)) {
+  if (node.nodeType == 3 && browser.webkit) {
     let rect = singleRect(textRange(node, offset, offset), 0)
     // Firefox returns bad results (the position before the space)
     // when querying a position directly after line-broken
     // whitespace. Detect this situation and and kludge around it
     if (browser.gecko && offset && /\s/.test(node.nodeValue[offset - 1]) && offset < node.nodeValue.length) {
       let rectBefore = singleRect(textRange(node, offset - 1, offset - 1), -1)
-      if (Math.abs(rectBefore.left - rect.left) < 1 && rectBefore.top == rect.top) {
+      if (rectBefore.top == rect.top) {
         let rectAfter = singleRect(textRange(node, offset, offset + 1), -1)
-        return flattenV(rectAfter, rectAfter.left < rectBefore.left)
+          if (rectAfter.top != rect.top) {
+            return flattenV(rectAfter, rectAfter.left < rectBefore.left)
+          }
       }
     }
     return rect

--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -283,7 +283,7 @@ export function coordsAtPos(view, pos) {
   let {node, offset} = view.docView.domFromPos(pos)
 
   // These browsers support querying empty text ranges
-  if (node.nodeType == 3 && browser.webkit) {
+  if (node.nodeType == 3 && (browser.webkit || browser.gecko) ) {
     let rect = singleRect(textRange(node, offset, offset), 0)
     // Firefox returns bad results (the position before the space)
     // when querying a position directly after line-broken


### PR DESCRIPTION
Coordinates on Firefox and Safari are invalid after line wrap point.

![pm-coordsAtPos-linewrap](https://user-images.githubusercontent.com/5718113/76790305-e3b5a180-67be-11ea-915f-5fb650dc7b56.gif)

Webkit seems to support querying empty text ranges and for Firefox we need to
compare before and after top positions to get correct coordinates.