### PR TITLE
Use fallback in setSelection to fix chrome bug

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -356,10 +356,23 @@ class ViewDesc {
     // Selection.extend can be used to create an 'inverted' selection
     // (one where the focus is before the anchor), but not all
     // browsers support it yet.
+    let domSelExtended = false
     if (domSel.extend || anchor == head) {
       domSel.collapse(anchorDOM.node, anchorDOM.offset)
-      if (anchor != head) domSel.extend(headDOM.node, headDOM.offset)
-    } else {
+      try {
+        if (anchor != head) domSel.extend(headDOM.node, headDOM.offset)
+        domSelExtended = true
+      } catch (err) {
+        // In some cases with Chrome the selection is empty after calling
+        // collapse, even when it should be valid. This appears to be a bug, but
+        // it is difficult to isolate. If this happens fallback to the old path
+        // without using extend.
+        if (!(err instanceof DOMException)) {
+          throw err;
+        }
+      }
+    }
+    if (!domSelExtended) {
       if (anchor > head) { let tmp = anchorDOM; anchorDOM = headDOM; headDOM = tmp }
       let range = document.createRange()
       range.setEnd(headDOM.node, headDOM.offset)

--- a/test/test-selection.js
+++ b/test/test-selection.js
@@ -268,4 +268,19 @@ describe("EditorView", () => {
     range.setStart(view.dom, 0)
     ist(range.toString(), "foobar")
   })
+
+  it("sets selection even if Selection.extend throws DOMException", () => {
+    let originalExtend = window.Selection.prototype.extend
+    window.Selection.prototype.extend = () => {
+      throw new DOMException("failed")
+    }
+    try {
+      let view = tempEditor({doc: doc(p("foo", img), hr, p(img, "bar"))})
+      setSel(view, NodeSelection.create(view.state.doc, 4))
+      view.dispatchEvent(event(DOWN))
+      ist(view.state.selection.from, 6)
+    } finally {
+      window.Selection.prototype.extend = originalExtend
+    }
+  })
 })


### PR DESCRIPTION
In some cases with Chrome the selection is empty after calling collapse, even when it should be valid. This appears to be a bug, but it is difficult to isolate. If this happens fallback to the old path without using extend.

See [discussion](https://discuss.prosemirror.net/t/domexception-in-chrome/2613)