### PR TITLE
clarify type for handlePaste event arg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -481,7 +481,7 @@ function needChromeSelectionReset(context, root) {
 //   handleTripleClick:: ?(view: EditorView, pos: number, event: dom.MouseEvent) → bool
 //   Called when the editor is triple-clicked, after `handleTripleClickOn`.
 //
-//   handlePaste:: ?(view: EditorView, event: dom.Event, slice: Slice) → bool
+//   handlePaste:: ?(view: EditorView, event: dom.ClipboardEvent, slice: Slice) → bool
 //   Can be used to override the behavior of pasting. `slice` is the
 //   pasted content parsed by the editor, but you can directly access
 //   the event to get at the raw content.


### PR DESCRIPTION
# Purpose
clarify type of event arg to [Clipboard event](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent) rather than a generic event, since this event should have a `clipboardData` property. This fixes some typescript issues.

please see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43904 for typescript fix.