### PR TITLE
Moving safari nonsense check to place where elt existence ensured

### DIFF
--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -240,14 +240,14 @@ export function posAtCoords(view, coords) {
   }
 
   let elt = root.elementFromPoint(coords.left, coords.top + 1), pos
-  // Safari's caretRangeFromPoint returns nonsense when on a draggable element
-  if (browser.safari && elt.draggable) node = offset = null
   if (!elt || !view.dom.contains(elt.nodeType != 1 ? elt.parentNode : elt)) {
     let box = view.dom.getBoundingClientRect()
     if (!inRect(coords, box)) return null
     elt = elementFromPoint(view.dom, coords, box)
     if (!elt) return null
   }
+  // Safari's caretRangeFromPoint returns nonsense when on a draggable element
+  if (browser.safari && elt.draggable) node = offset = null
   elt = targetKludge(elt, coords)
   if (node) {
     if (browser.gecko && node.nodeType == 1) {


### PR DESCRIPTION
Safari: in some cases posAtCoords throws an error `TypeError: null is not an object (evaluating 'elt.draggable')`.
This is caused by safari nonsense check in place where elt may be null and breaks position retrieval.

**Solution** - moving safari nonsense check to place where elt existence ensured.