### PR TITLE
FIX cross inline node decoration

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -1215,7 +1215,7 @@ function iterDeco(parent, deco, onWidget, onNode) {
     }
 
     for (let i = 0; i < active.length; i++) if (active[i].to <= offset) active.splice(i--, 1)
-    while (decoIndex < locals.length && locals[decoIndex].from == offset) active.push(locals[decoIndex++])
+    while (decoIndex < locals.length && locals[decoIndex].from <= offset && locals[decoIndex].to > offset) active.push(locals[decoIndex++])
 
     let end = offset + child.nodeSize
     if (child.isText) {


### PR DESCRIPTION
If a decoration start in a inline node ,and end in other text node. the decoration will go wrong

### The sample:
tag `<a>` schema spec type is a inline node(not a mark)
tag `<p>` schema spec type is a block node
decoration from:`13` to:`21`

`<p>normal text<a href="http://foo.bar">LINK</a>normal text</p>`

### Before fix
![Screen Shot 2020-06-01 at 7 31 18 PM](https://user-images.githubusercontent.com/2216417/83405745-c9937300-a43f-11ea-8ebe-30a0ca4183cb.png)
### After fix
![Screen Shot 2020-06-01 at 7 30 49 PM](https://user-images.githubusercontent.com/2216417/83405763-d6b06200-a43f-11ea-933f-0bb24d519be9.png)

spend several hours, i found the reason that the decoration active state was lost after `iterDeco` in child inline node

my English is poor,  Hope it helps 