### PR TITLE
Tweaking lastIOSEnter timing values and making sure to clear the lastIOSEnter fallback timeout

### DIFF
--- a/src/domchange.js
+++ b/src/domchange.js
@@ -151,7 +151,7 @@ export function readDOMChange(view, from, to, typeOver, addedNodes) {
   let nextSel
   // If this looks like the effect of pressing Enter (or was recorded
   // as being an iOS enter press), just dispatch an Enter key instead.
-  if (((browser.ios && view.lastIOSEnter > Date.now() - 100 &&
+  if (((browser.ios && view.lastIOSEnter > Date.now() - 225 &&
         (!inlineChange || addedNodes.some(n => n.nodeName == "DIV" || n.nodeName == "P"))) ||
        (!inlineChange && $from.pos < parse.doc.content.size &&
         (nextSel = Selection.findFrom(parse.doc.resolve($from.pos + 1), 1, true)) &&

--- a/src/input.js
+++ b/src/input.js
@@ -24,6 +24,7 @@ export function initInput(view) {
   view.lastSelectionTime = 0
 
   view.lastIOSEnter = 0
+  view.lastIOSEnterFallbackTimeout = null
 
   view.composing = false
   view.composingTimeout = null
@@ -62,6 +63,7 @@ export function destroyInput(view) {
   for (let type in view.eventHandlers)
     view.dom.removeEventListener(type, view.eventHandlers[type])
   clearTimeout(view.composingTimeout)
+  clearTimeout(view.lastIOSEnterFallbackTimeout)
 }
 
 export function ensureListeners(view) {
@@ -107,12 +109,12 @@ editHandlers.keydown = (view, event) => {
   if (browser.ios && event.keyCode == 13 && !event.ctrlKey && !event.altKey && !event.metaKey) {
     let now = Date.now()
     view.lastIOSEnter = now
-    setTimeout(() => {
+    view.lastIOSEnterFallbackTimeout = setTimeout(() => {
       if (view.lastIOSEnter == now) {
         view.someProp("handleKeyDown", f => f(view, keyEvent(13, "Enter")))
         view.lastIOSEnter = 0
       }
-    }, 50)
+    }, 200)
   } else if (view.someProp("handleKeyDown", f => f(view, event)) || captureKeyDown(view, event)) {
     event.preventDefault()
   } else {


### PR DESCRIPTION
On older iOS devices (like an iPhone 6), the timing between a keydown for pressing enter and when the enter mutation occurs can sometimes be as high as 175ms. With the current lastIOSEnter implementation, you occasionally can get a double enter bug where both the iOS enter fallback executes a custom enter and then immediately after, the original native enter mutates the dom.

Using timeout values of around 200ms seems to handle this problem most of the time, even though that timeout timeline is a bit long. I think ideally we would go with a more deterministic approach on when to use a fallback but I can't think of a way to do that.