### PR TITLE
update documentation of`nodeViews`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -527,7 +527,7 @@ function changedNodeViews(a, b) {
 //   Can be used to transform pasted content before it is applied to
 //   the document.
 //
-//   nodeViews:: ?Object<(node: Node, view: EditorView, getPos: () → number, decorations: [Decoration]) → NodeView>
+//   nodeViews:: ?Object<(node: union<Node, Mark>, view: EditorView, getPos: union<() → number, bool>, decorations: [Decoration]) → NodeView>
 //   Allows you to pass custom rendering and behavior logic for nodes
 //   and marks. Should map node and mark names to constructor
 //   functions that produce a [`NodeView`](#view.NodeView) object


### PR DESCRIPTION
After updating the type of `node` to include `Mark` and `getPos` to include `bool`, the reference documentation looks like

![Screen Shot 2020-07-25 at 9 38 51 PM](https://user-images.githubusercontent.com/15721634/88471537-5d714080-cebf-11ea-96db-df50ca2db0ab.png)
