### PR TITLE
Fix incorrect ctrl+drag behavior.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,18 @@ export class EditorView {
     // When editor content is being dragged, this object contains
     // information about the dragged slice and whether it is being
     // copied or moved. At any other time, it is null.
+    // Whether move is true depends on what the `e.transferData.dropEffect`
+    // is set to during the event (`"copy"` will set move to `false`, all other values
+    // will set move to `true`).
+    // Note that ProseMirror will patch `dropEffect` for events it has handled
+    // (e.g. [stopEvent](#view.NodeView.stopEvent) will have the patched value,
+    // but not [handleDOMEvents](#view.EditorProps.handleDOMEvents) which run
+    // before prosemirror handles any events). If it receives `"none"` it will fall back
+    // to checking the platform specific drag modifier keys and set
+    // `e.transferData.dropEffect` accordingly, otherwise it will use the value set
+    // on the event. This means intentionally setting it to `"none"`
+    // (e.g.in a [handleDOMEvents](#view.EditorProps.handleDOMEvents) handler) will
+    // have no effect. To prevent a drop, you can just `e.preventDefault(); return true;`.
     this.dragging = null
 
     initInput(this)

--- a/src/index.js
+++ b/src/index.js
@@ -61,18 +61,6 @@ export class EditorView {
     // When editor content is being dragged, this object contains
     // information about the dragged slice and whether it is being
     // copied or moved. At any other time, it is null.
-    // Whether move is true depends on what the `e.transferData.dropEffect`
-    // is set to during the event (`"copy"` will set move to `false`, all other values
-    // will set move to `true`).
-    // Note that ProseMirror will patch `dropEffect` for events it has handled
-    // (e.g. [stopEvent](#view.NodeView.stopEvent) will have the patched value,
-    // but not [handleDOMEvents](#view.EditorProps.handleDOMEvents) which run
-    // before prosemirror handles any events). If it receives `"none"` it will fall back
-    // to checking the platform specific drag modifier keys and set
-    // `e.transferData.dropEffect` accordingly, otherwise it will use the value set
-    // on the event. This means intentionally setting it to `"none"`
-    // (e.g.in a [handleDOMEvents](#view.EditorProps.handleDOMEvents) handler) will
-    // have no effect. To prevent a drop, you can just `e.preventDefault(); return true;`.
     this.dragging = null
 
     initInput(this)

--- a/src/input.js
+++ b/src/input.js
@@ -558,44 +558,34 @@ class Dragging {
 
 const dragCopyModifier = browser.mac ? "altKey" : "ctrlKey"
 
-/**
- * Patches this chromium issue as much as possible:
- * https://bugs.chromium.org/p/chromium/issues/detail?id=509752&q=39399
- * The patch makes it impossible to set the dropEffect to "none",
- * but if we don't want the drop to happen,
- * we can always just preventDefault() the event.
- */
-let globalChromiumDropEffect = "none"
-const isChromiumBased = window.chrome !== undefined
-function patchChromiumDropEffect(e, { reset = false } = {}) {
-  if (isChromiumBased && e.dataTransfer) {
+// Patches this chromium issue as much as possible:
+// https://bugs.chromium.org/p/chromium/issues/detail?id=509752&q=39399
+// Applies to all browsers for consistency.
+// The patch makes it impossible to set the dropEffect to "none" and only
+// affects events first handled by prosemirror. See view.dragging docs.
+let globalDropEffect = "none"
+
+function patchDropEffect(e, { reset = false } = {}) {
+  if (e.dataTransfer) {
     if (e.dataTransfer.dropEffect === "none") {
       e.dataTransfer.dropEffect = e[dragCopyModifier] ? "copy" : "move"
     }
-    globalChromiumDropEffect = e.dataTransfer.dropEffect
+    globalDropEffect = e.dataTransfer.dropEffect
   }
   if (reset) {
     window.setTimeout(() => {
-      globalChromiumDropEffect = "none"
+      globalDropEffect = "none"
     }, 0)
   }
 }
 
-function dragModifierIsPressed(e) {
-  if (!e.dataTransfer) return false
-  if (isChromiumBased) {
-    return globalChromiumDropEffect === "copy"
-  } else {
-    return e.dataTransfer.dropEffect === "copy"
-  }
-}
 
 handlers.dragstart = (view, e) => {
   let mouseDown = view.mouseDown
   if (mouseDown) mouseDown.done()
   if (!e.dataTransfer) return
 
-  patchChromiumDropEffect(e)
+  patchDropEffect(e)
 
   let sel = view.state.selection
   let pos = sel.empty ? null : view.posAtCoords(eventCoords(e))
@@ -612,7 +602,7 @@ handlers.dragstart = (view, e) => {
   e.dataTransfer.clearData()
   e.dataTransfer.setData(brokenClipboardAPI ? "Text" : "text/html", dom.innerHTML)
   if (!brokenClipboardAPI) e.dataTransfer.setData("text/plain", text)
-  view.dragging = new Dragging(slice, !dragModifierIsPressed(e))
+  view.dragging = new Dragging(slice, globalDropEffect !== "copy")
 }
 
 handlers.dragend = view => {
@@ -621,14 +611,14 @@ handlers.dragend = view => {
 
 
 editHandlers.dragover = editHandlers.dragenter = (view, e) => {
-  patchChromiumDropEffect(e)
-  if (view.dragging) view.dragging.move = !dragModifierIsPressed(e)
+  patchDropEffect(e)
+  if (view.dragging) view.dragging.move = globalDropEffect !== "copy"
   e.preventDefault()
 }
 
-editHandlers.drop = (view, e) => {
-  patchChromiumDropEffect(e, {reset: true})
-  view.dragging.move = !dragModifierIsPressed(e)
+editHandlers.drop = (e) => {
+  patchDropEffect(e, {reset: true})
+  view.dragging.move = globalDropEffect !== "copy"
   let dragging = view.dragging
   view.dragging = null
 


### PR DESCRIPTION
To fix https://discuss.prosemirror.net/t/weird-ctrl-drag-selection-behavior/3072

Now initially I made a simple fix, just making sure `view.dragging.move` was updated during drag events and on drop as well, to correctly emulate the browser's behavior.

This worked, on the surface, but it made the ctrl+drag copy behavior impossible to stop. I looked into this a bit and found out about [`e.dataTransfer.dropEffect`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect), which should really be what determines `view.dragging.move`. But, there is a [bug in chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=509752&q=39399). It is always `"none"` in chromium based browsers. It can't be changed from dragover/enter listeners like it should be (the last listener should determine what it's set to in the drop event, [example](https://jsfiddle.net/nLwy3e59/), compare with firefox where it works). I played around with different solutions and I think this one is the one has the fewest drawbacks. The solution should be checked in more browsers though since in any non-chromium browsers this would now rely on `e.dataTransfer.dropEffect` functioning correctly.

The other option would be to use the chrome fallback on all browsers so they all behave the same. The only thing this would mean, as far as I can tell, is that you would not be able to set `e.dataTransfer.dropEffect` to `"none"`, but then, if we didn't want the content moved or copied, we would just `e.preventDefault(); return true;` and we were already ignoring the different dropEffects.

The only thing I could not fix is that the cursor does not change to indicate whether the drag modifier is being held. This is because the dragover/dragenter handler's do `e.preventDefault()`, but from what I understand this is recommended and shouldn't be removed. The good news is that it's possible to work around it. Without `e.preventDefault()`, the cursor can't be changed on drag events, but with `e.preventDefault()` they can, so it's just a matter of adding a some move/copy css classes to the editor corresponding to the state of `e.dataTransfer.dropEffect` and also getting the right images since these do not seem to be included in the possible cursor properties. I'll try to look into it properly this week.