### PR TITLE
fix: Incorrectly parsing content from the clipboard

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -582,7 +582,10 @@ handlers.dragstart = (view, e) => {
 }
 
 handlers.dragend = view => {
-  window.setTimeout(() => view.dragging = null, 50)
+  let dragging = view.dragging
+  window.setTimeout(() => {
+    if (view.dragging == dragging)  view.dragging = null
+  }, 50)
 }
 
 editHandlers.dragover = editHandlers.dragenter = (_, e) => e.preventDefault()


### PR DESCRIPTION
I‘ve found a case that when dragging out of window and then quickly dragging a node will cause an incorrect parse behavior.
Because when the second drag starts, the previous `dragend` hasn't clean up the `view.dragging`.
It is easier to reproduce from a computer with poor performance.
Below is what I reproduce at [official website](https://prosemirror.net)


![drag-issuse-min](https://user-images.githubusercontent.com/17680884/94039457-5486e780-fdfa-11ea-8869-9ca548de274e.gif)
