### PR TITLE
Fix paste when using SHIFT+INS

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -530,7 +530,7 @@ function capturePaste(view, e) {
 }
 
 function doPaste(view, text, html, e) {
-  let slice = parseFromClipboard(view, text, html, view.shiftKey, view.state.selection.$from)
+  let slice = parseFromClipboard(view, text, html, view.shiftKey && view.ctrlKey, view.state.selection.$from)
   if (view.someProp("handlePaste", f => f(view, e, slice || Slice.empty)) || !slice) return
 
   let singleNode = sliceSingleNode(slice)


### PR DESCRIPTION
Paste keyboard shortcut std. is also **SHIFT + INSERT** - this however will always paste as `plainText` for the `parseFromClipboard` because of (**CTRL + SHIFT + V**). To avoid this I added that the CTRL key also needs to be held while SHIFT is to get a plain text paste.

Not tested on Mac but I assume that the CTRL is Cmd there.