### PR TITLE
Enable a image in PNG format to be pasted into a Prosemirror document.

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -542,7 +542,9 @@ function doPaste(view, text, html, e) {
 editHandlers.paste = (view, e) => {
   let data = brokenClipboardAPI ? null : e.clipboardData
   let html = data && data.getData("text/html"), text = data && data.getData("text/plain")
-  if (data && (html || text || data.files.length)) {
+  if (data.items && data.items.length > 0 && data.items[0].type === "image/png") {
+    capturePaste(view, e)
+  } else if (data && (html || text || data.files.length)) {
     doPaste(view, text, html, e)
     e.preventDefault()
   } else {


### PR DESCRIPTION
This PR enables Prosemirror to paste a image in the PNG format from the system clipboard into a Prosemirror document. The resulting document will contain an `<img>` element whose `src` is a URI base 64 conversion of the PNG.

The PR's code is simpler than one might expect.  No code is necessary to wrap that PNG in a `<img>`. The browser does that itself any time a PNG is pasted into a `contenteditable` element. All this PR does is call `capturePaste()` when appropriate.

I find that `capturePaste()` will properly append the `<img>` to the Prosemirror document and that the Prosemirror undo stack continues to operate properly.

The motivation for this PR is to enable authors to copy screenshots from the system clipboard into a Prosemirror document as discussed in https://discuss.prosemirror.net/t/paste-systems-screenshot/2402/3.