### PR TITLE
only remove ProseMirror-hideselection when selection.visible=true

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -103,7 +103,7 @@ function removeClassOnSelectionChange(view) {
   doc.addEventListener("selectionchange", view.hideSelectionGuard = () => {
     if (domSel.anchorNode != node || domSel.anchorOffset != offset) {
       doc.removeEventListener("selectionchange", view.hideSelectionGuard)
-      view.dom.classList.remove("ProseMirror-hideselection")
+      view.state.selection.visible && view.dom.classList.remove("ProseMirror-hideselection")
     }
   })
 }


### PR DESCRIPTION
Right now, `ProseMirror-hideselection` is removed as a class from the editor regardless of whether the current value of `selection.visible`. This results in a visual flicker when `selection.visible=false`, but `ProseMirror-hideselection` is removed and then added again within a short timespan.

An example of a selection with `selection.visible=false` is a [`GapCursor` selection](https://github.com/ProseMirror/prosemirror-gapcursor/blob/36ecfd4ba877448181628bb8306fd2397d593d91/src/gapcursor.js#L83).

The issue begins in `removeClassOnSelectionChange`, which removes `ProseMirror-hideselection` on `selectionchange`.
https://github.com/ProseMirror/prosemirror-view/blob/4c37fc904a517e8617d6ceb20ecf8ac85a1ab8f5/src/selection.js#L98-L109

Then after the cursor is briefly displayed because `ProseMirror-hideselection` is not toggled, `selectionToDOM` is called which re-adds `ProseMirror-hideselection`:
https://github.com/ProseMirror/prosemirror-view/blob/4c37fc904a517e8617d6ceb20ecf8ac85a1ab8f5/src/selection.js#L34-L68


Edit: This only seems to be an issue on Chrome; Safari does not re-render the dom when `ProseMirror-hideselection` is removed and added in a short period.

https://user-images.githubusercontent.com/15721634/107896715-eeefe080-6eeb-11eb-94cb-8cd611b99c6b.mov

