### PR TITLE
trim className before split to avoid empty className

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -988,7 +988,7 @@ function patchAttributes(dom, prev, cur) {
       dom.setAttribute(name, cur[name])
   if (prev.class != cur.class) {
     let prevList = prev.class ? prev.class.split(" ") : nothing
-    let curList = cur.class ? cur.class.split(" ") : nothing
+    let curList = cur.class ? cur.class.trim().split(" ") : nothing
     for (let i = 0; i < prevList.length; i++) if (curList.indexOf(prevList[i]) == -1)
       dom.classList.remove(prevList[i])
     for (let i = 0; i < curList.length; i++) if (prevList.indexOf(curList[i]) == -1)


### PR DESCRIPTION
in `function patchAttributes(dom, prev, cur)`, className like 'someClassName ' get an array contains empty element after split(' ') called. `dom.classList.add(emptyString)` will case an exception : `Uncaught (in promise) DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.`  