### PR TITLE
Pass inner decorations to nodeView on init and update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -540,7 +540,7 @@ function changedNodeViews(a, b) {
 //   Can be used to transform pasted content before it is applied to
 //   the document.
 //
-//   nodeViews:: ?Object<(node: Node, view: EditorView, getPos: () → number, decorations: [Decoration]) → NodeView>
+//   nodeViews:: ?Object<(node: Node, view: EditorView, getPos: () → number, decorations: [Decoration], innerDecorations: DecorationSet) → NodeView>
 //   Allows you to pass custom rendering and behavior logic for nodes
 //   and marks. Should map node and mark names to constructor
 //   functions that produce a [`NodeView`](#view.NodeView) object
@@ -555,6 +555,11 @@ function changedNodeViews(a, b) {
 //   normal way, and you will usually just want to ignore this, but
 //   they can also be used as a way to provide context information to
 //   the node view without adding it to the document itself.
+//
+//   `decorationSet` is a DecorationSet containing the decorations that
+//   are active within the node's range. These may be useful if the
+//   NodeView being rendered needs access to decorations, perhaps to
+//   pass them to a nested Prosemirror instance.
 //
 //   clipboardSerializer:: ?DOMSerializer
 //   The DOM serializer to use when putting content onto the

--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -30,12 +30,14 @@ import browser from "./browser"
 //   is not present, the node view itself is responsible for rendering
 //   (or deciding not to render) its child nodes.
 //
-//   update:: ?(node: Node, decorations: [Decoration]) → bool
+//   update:: ?(node: Node, decorations: [Decoration], innerDecorations: DecorationSet) → bool
 //   When given, this will be called when the view is updating itself.
-//   It will be given a node (possibly of a different type), and an
-//   array of active decorations (which are automatically drawn, and
-//   the node view may ignore if it isn't interested in them), and
-//   should return true if it was able to update to that node, and
+//   It will be given a node (possibly of a different type), an
+//   array of active decorations around the node (which are automatically
+//   drawn, and the node view may ignore if it isn't interested in them),
+//   and a DecorationSet that represents any decorations that apply to
+//   the range covered by the given node (which again may be ignored).
+//   It should return true if it was able to update to that node, and
 //   false otherwise. If the node view has a `contentDOM` property (or
 //   no `dom` property), updating its child nodes will be handled by
 //   ProseMirror.
@@ -597,7 +599,7 @@ class NodeViewDesc extends ViewDesc {
       // own position)
       if (!descObj) return pos
       if (descObj.parent) return descObj.parent.posBeforeChild(descObj)
-    }, outerDeco)
+    }, outerDeco, innerDeco)
 
     let dom = spec && spec.dom, contentDOM = spec && spec.contentDOM
     if (node.isText) {
@@ -855,7 +857,7 @@ class CustomNodeViewDesc extends NodeViewDesc {
   update(node, outerDeco, innerDeco, view) {
     if (this.dirty == NODE_DIRTY) return false
     if (this.spec.update) {
-      let result = this.spec.update(node, outerDeco)
+      let result = this.spec.update(node, outerDeco, innerDeco)
       if (result) this.updateInner(node, outerDeco, innerDeco, view)
       return result
     } else if (!this.contentDOM && !node.isLeaf) {


### PR DESCRIPTION
This PR passes the decorations applied to a nodeView's content to its initialiser and update() method.

This enables the use case discussed [here](https://discuss.prosemirror.net/t/is-it-possible-to-get-hold-of-decorations-that-cover-the-range-managed-by-a-nodeview-in-that-nodeview/3544) – Prosemirror instances nested within nodeViews will be able to make use of their parent's decorations.
