### PR TITLE
Fix scroll when editor has css transform:scale()

### DIFF
--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -12,9 +12,11 @@ function getSide(value, side) {
 
 function clientRect(node) {
   let rect = node.getBoundingClientRect()
+  // Adjust for elements with style "transform: scale()"
+  let scale = (rect.width / node.offsetWidth) || 1;
   // Make sure scrollbar width isn't included in the rectangle
-  return {left: rect.left, right: rect.left + node.clientWidth,
-          top: rect.top, bottom: rect.top + node.clientHeight}
+  return {left: rect.left, right: rect.left + node.clientWidth * scale,
+          top: rect.top, bottom: rect.top + node.clientHeight * scale}
 }
 
 export function scrollRectIntoView(view, rect, startDOM) {

--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -13,10 +13,11 @@ function getSide(value, side) {
 function clientRect(node) {
   let rect = node.getBoundingClientRect()
   // Adjust for elements with style "transform: scale()"
-  let scale = (rect.width / node.offsetWidth) || 1
+  let scaleX = (rect.width / node.offsetWidth) || 1
+  let scaleY = (rect.height / node.offsetHeight) || 1
   // Make sure scrollbar width isn't included in the rectangle
-  return {left: rect.left, right: rect.left + node.clientWidth * scale,
-          top: rect.top, bottom: rect.top + node.clientHeight * scale}
+  return {left: rect.left, right: rect.left + node.clientWidth * scaleX,
+          top: rect.top, bottom: rect.top + node.clientHeight * scaleY}
 }
 
 export function scrollRectIntoView(view, rect, startDOM) {

--- a/src/domcoords.js
+++ b/src/domcoords.js
@@ -13,7 +13,7 @@ function getSide(value, side) {
 function clientRect(node) {
   let rect = node.getBoundingClientRect()
   // Adjust for elements with style "transform: scale()"
-  let scale = (rect.width / node.offsetWidth) || 1;
+  let scale = (rect.width / node.offsetWidth) || 1
   // Make sure scrollbar width isn't included in the rectangle
   return {left: rect.left, right: rect.left + node.clientWidth * scale,
           top: rect.top, bottom: rect.top + node.clientHeight * scale}


### PR DESCRIPTION
This fixes an issue with editors inside elements with style "transform: scale(xx)" that sometimes causes scrolling to take place too early (when scale > 1) or after the cursor already left the window boundary (when scale < 1), since clientWidth and clientHeight being used to offset the scrollbars are unscaled.