### PR TITLE
check if focusNode of root selection is contained within view dom

### DIFF
--- a/src/capturekeys.js
+++ b/src/capturekeys.js
@@ -1,7 +1,7 @@
 import {Selection, NodeSelection, TextSelection, AllSelection} from "prosemirror-state"
 import browser from "./browser"
 import {domIndex, selectionCollapsed} from "./dom"
-import {selectionToDOM} from "./selection"
+import {selectionToDOM, hasFocusAndSelection} from "./selection"
 
 function moveSelectionBlock(state, dir) {
   let {$anchor, $head} = state.selection
@@ -61,6 +61,7 @@ function isIgnorable(dom) {
 // Make sure the cursor isn't directly after one or more ignored
 // nodes, which will confuse the browser's cursor motion logic.
 function skipIgnoredNodesLeft(view) {
+  if (!hasFocusAndSelection(view)) return
   let sel = view.root.getSelection()
   let node = sel.focusNode, offset = sel.focusOffset
   if (!node) return
@@ -109,6 +110,7 @@ function skipIgnoredNodesLeft(view) {
 // Make sure the cursor isn't directly before one or more ignored
 // nodes.
 function skipIgnoredNodesRight(view) {
+  if (!hasFocusAndSelection(view)) return
   let sel = view.root.getSelection()
   let node = sel.focusNode, offset = sel.focusOffset
   if (!node) return


### PR DESCRIPTION
I'm on `prosemirror-view@1.18.4`, and am running into a runtime problem when holding the up or down arrow keys when the prosemirror-gapcursor is at the edge of the document.

The error I'm encountering comes from

```js
function isBlockNode(dom) {
  var desc = dom.pmViewDesc; // TypeError: Cannot read property 'pmViewDesc' of null
  return desc && desc.node && desc.node.isBlock
}
```

with the stack trace being

```js
Uncaught TypeError: Cannot read property 'pmViewDesc' of null
    at isBlockNode (index.es.js:2345)
    at skipIgnoredNodesRight (index.es.js:2321)
    at captureKeyDown (index.es.js:2466)
    at push../node_modules/prosemirror-view/dist/index.es.js.editHandlers.keydown (index.es.js:3374)
    at HTMLDivElement.view.dom.addEventListener.view.eventHandlers.<computed> (index.es.js:3299)
```

If we open up `skipIgnoredNodesRight`, the issue cascades like so:

```js
function skipIgnoredNodesRight(view) {
  var sel = view.root.getSelection();
  var node = sel.focusNode, offset = sel.focusOffset; // 1. node is not contained within view.dom, but is not null
  if (!node) { return }
  var len = nodeLen(node);
  var moveNode, moveOffset;
  for (;;) {
    if (offset < len) {
      if (node.nodeType != 1) { break }
      var after = node.childNodes[offset];
      if (isIgnorable(after)) {
        moveNode = node;
        moveOffset = ++offset;
      }
      else { break }
    } else if (isBlockNode(node)) { // 3. because node is now null, TypeError
      break
    } else {
      var next = node.nextSibling;
      while (next && isIgnorable(next)) {
        moveNode = next.parentNode;
        moveOffset = domIndex(next) + 1;
        next = next.nextSibling;
      }
      if (!next) {
        node = node.parentNode; // 2. keeps climbing until node is #document, which then node = node.parentNode = null
        if (node == view.dom) { break }
        offset = len = 0;
      } else {
        node = next;
        offset = 0;
        len = nodeLen(node);
      }
    }
  }
  if (moveNode) { setSelFocus(view, sel, moveNode, moveOffset); }
}
```

In my specific case, the `focusNode` of `view.root.getSelection()`  when arrowing down somehow landed here
```html
    <next-route-announcer>
      /* sel.focusNode */
      <p aria-live="assertive" id="__next-route-announcer__" role="alert" style="border: 0px; clip: rect(0px, 0px, 0px, 0px); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; overflow-wrap: normal;"></p>
    </next-route-announcer>
  </body>
</html>
```

![prosemirror-view](https://user-images.githubusercontent.com/15721634/117902417-3f27d600-b282-11eb-8850-73a6c4c9505b.PNG)


Seems sort of related to #588 and #828 with issues with selections outside of the editor view, and `skipIgnoredNodesLeft` and `skipIgnoredNodesRight` (?). I'm not exactly sure of the interactions between Chrome and prosemirror-gapcursor which lead to the `var sel = view.root.getSelection();` being placed _outside_ of the editor even though `document.activeElement = view.dom` still. 

