### PR TITLE
DecorationSet: Filter by predicate with range arguments excluded

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -243,6 +243,10 @@ export class DecorationSet {
   // assumed to match.
   find(start, end, predicate) {
     let result = []
+    if (typeof start === "function" && end == null && predicate == null) {
+      predicate = start
+      start = null
+    }    
     this.findInner(start == null ? 0 : start, end == null ? 1e9 : end, result, 0, predicate)
     return result
   }

--- a/test/test-decoration.js
+++ b/test/test-decoration.js
@@ -103,6 +103,11 @@ describe("DecorationSet", () => {
       let set = build(doc(blockquote(blockquote(p("a")))), {from: 3, to: 4, name: "X"}, {from: 3, to: 4, name: "Y"})
       ist(set.find(undefined, undefined, x => x.name == "Y").map(d => d.spec.name).join(), "Y")
     })
+
+    it("can filter by predicate with range arguments excluded", () => {
+      let set = build(doc(blockquote(blockquote(p("a")))), {from: 3, to: 4, name: "X"}, {from: 3, to: 4, name: "Y"})
+      ist(set.find(x => x.name == "Y").map(d => d.spec.name).join(), "Y")
+    })
   })
 
   describe("map", () => {


### PR DESCRIPTION
Reading the documentation for `DecorationSet` I interpreted the range arguments as optional while still being able to pass-in a predicate like this:

```js
decoration.find((deco) => ...)
``

In practice I have to explicitly pass `undefined` as start and end values:

```js
decoration.find(undefined, undefined, (deco) => ...)
```

This PR updates the method to function the way I expected, but I recognize that might just be syntactic sugar, a little magical and perhaps unwanted. 

I updated the method to recognize when I'm only passing in a single function as an argument, assume that's my predicate and treat the start/end values as `null` so it's applied to the entire range.