### PR TITLE
Add .map to DecorationSource interface 

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -419,7 +419,7 @@ export class DecorationSet {
 // decorations. Implemented by [`DecorationSet`](#view.DecorationSet),
 // and passed to [node views](#view.EditorProps.nodeViews).
 //
-// map:: (Mapping, Node) → DecorationSet
+// map:: (Mapping, Node) → DecorationSource
 // Map the set of decorations in response to a change in the
 // document.
 
@@ -440,11 +440,10 @@ class DecorationGroup {
   }
 
   map(mapping, doc) {
-    const mappedMembers = [];
-    for (let i = 0; i < this.members.length; i++) {
-      mappedMembers.push(this.members[i].map(mapping, doc, options))
-    }
-    return DecorationGroup.from(mappedMembers)
+    const mappedDecos = this.members.map(
+      member => member.map(mapping, doc, noSpec)
+    )
+    return DecorationGroup.from(mappedDecos)
   }
 
   forChild(offset, child) {

--- a/src/decoration.js
+++ b/src/decoration.js
@@ -419,16 +419,9 @@ export class DecorationSet {
 // decorations. Implemented by [`DecorationSet`](#view.DecorationSet),
 // and passed to [node views](#view.EditorProps.nodeViews).
 //
-// map:: (Mapping, Node, ?Object) → DecorationSet
+// map:: (Mapping, Node) → DecorationSet
 // Map the set of decorations in response to a change in the
 // document.
-//
-//   options::- An optional set of options.
-//
-//     onRemove:: ?(decorationSpec: Object)
-//     When given, this function will be called for each decoration
-//     that gets dropped as a result of the mapping, passing the
-//     spec of that decoration.
 
 const empty = new DecorationSet()
 
@@ -446,7 +439,7 @@ class DecorationGroup {
     this.members = members
   }
 
-  map(mapping, doc, options) {
+  map(mapping, doc) {
     const mappedMembers = [];
     for (let i = 0; i < this.members.length; i++) {
       mappedMembers.push(this.members[i].map(mapping, doc, options))

--- a/src/decoration.js
+++ b/src/decoration.js
@@ -418,6 +418,17 @@ export class DecorationSet {
 // An object that can [provide](#view.EditorProps.decorations)
 // decorations. Implemented by [`DecorationSet`](#view.DecorationSet),
 // and passed to [node views](#view.EditorProps.nodeViews).
+//
+// map:: (Mapping, Node, ?Object) → DecorationSet
+// Map the set of decorations in response to a change in the
+// document.
+//
+//   options::- An optional set of options.
+//
+//     onRemove:: ?(decorationSpec: Object)
+//     When given, this function will be called for each decoration
+//     that gets dropped as a result of the mapping, passing the
+//     spec of that decoration.
 
 const empty = new DecorationSet()
 
@@ -433,6 +444,14 @@ DecorationSet.removeOverlap = removeOverlap
 class DecorationGroup {
   constructor(members) {
     this.members = members
+  }
+
+  map(mapping, doc, options) {
+    const mappedMembers = [];
+    for (let i = 0; i < this.members.length; i++) {
+      mappedMembers.push(this.members[i].map(mapping, doc, options))
+    }
+    return DecorationGroup.from(mappedMembers)
   }
 
   forChild(offset, child) {


### PR DESCRIPTION
... and implement for DecorationGroup.

## Why?

We're working on a [library](https://github.com/guardian/prosemirror-elements) that aims it easier to model arbitrary combinations of nested fields representing different sorts of data within a Prosemirror instance. This includes nested rich text fields.

It's useful to be able to pass decorations from the parent editor to its children. This lets us represent spellcheck annotations, or other users' cursors, with a single plugin in the parent editor. This was implemented in #87.

In our plugin, when we receive a `DecorationSource` in a child editor, it represents the decorations for a NodeView that contains the entire `Element`, within which that child is one of what may be many nodes. Thus, we must map these decorations through the offset of that node relative to its parent.

This PR adds a `.map` method to `DecorationSource`, and implements it for `DecorationGroup`, to address that use case. Here's an example of it working – the parent editor is using [prosemirror-typerighter](https://github.com/guardian/prosemirror-typerighter), and the child node in a prosemirror-elements `Element` is displaying decorations correctly.

<img width="1068" alt="Screenshot 2021-08-06 at 09 39 15" src="https://user-images.githubusercontent.com/7767575/128486098-bbfd3359-dfaa-41ab-924a-7fa8117cc75d.png">

## Questions

I'm not quite sure of the best way to write a unit test for this new method – any guidance v. welcome.