### PR TITLE
Use `::` to signify pseudo element

### DIFF
--- a/style/prosemirror.css
+++ b/style/prosemirror.css
@@ -33,7 +33,7 @@ li.ProseMirror-selectednode {
   outline: none;
 }
 
-li.ProseMirror-selectednode:after {
+li.ProseMirror-selectednode::after {
   content: "";
   position: absolute;
   left: -32px;


### PR DESCRIPTION
Not strictly necessary, but adds clarity imo