### PR TITLE
Add a class name to distinguish ProseMirror hack nodes from regular nodes

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -1258,6 +1258,7 @@ class ViewTreeUpdater {
     } else {
       let dom = document.createElement(nodeName)
       if (nodeName == "IMG") dom.className = "ProseMirror-separator"
+      if (nodeName == "BR") dom.className = "ProseMirror-trailingBreak"
       this.top.children.splice(this.index++, 0, new TrailingHackViewDesc(this.top, nothing, dom, null))
       this.changed = true
     }


### PR DESCRIPTION
ProseMirror looks at the schema to decide when to insert hack nodes, this is fine most of the time. But an `inline` node may have styles that make it display `block`, contrary to its schema spec. Meaning the hack is applied when it is not needed, which can lead to display issues.

This PR adds a class name to allow hack nodes to be differentiated from nodes that are actually part of the document. It does not fix the above, but it goes some way to allow developers to work around the issue if it affects them.
