### PR TITLE
Fix matchesNode of null runtime error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export class EditorView {
 
     let scroll = reconfigured ? "reset"
         : state.scrollToSelection > prev.scrollToSelection ? "to selection" : "preserve"
-    let updateDoc = redraw || !this.docView.matchesNode(state.doc, outerDeco, innerDeco)
+    let updateDoc = redraw || this.docView && !this.docView.matchesNode(state.doc, outerDeco, innerDeco)
     if (updateDoc || !state.selection.eq(prev.selection)) updateSel = true
     let oldScrollPos = scroll == "preserve" && updateSel && this.dom.style.overflowAnchor == null && storeScrollPos(this)
 


### PR DESCRIPTION
When an editor is removed from the page, it seems that `matchesNode` gets hit which means that if this.docView is null, it causes a runtime error.