### PR TITLE
Fix Markdown syntax in DirectEditorProps section

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -642,7 +642,7 @@ function checkStateComponent(plugin) {
 //   view](#state.PluginSpec.view) and
 //   [props](#state.PluginSpec.props). Passing plugins with a state
 //   component (a [state field](#state.PluginSpec.state) field or a
-//   [transaction)[#state.PluginSpec.filterTransaction] filter or
+//   [transaction](#state.PluginSpec.filterTransaction) filter or
 //   appender) will result in an error, since such plugins must be
 //   present in the state to work.
 //


### PR DESCRIPTION
This PR fixes Markdown link syntax in the prosemirror-view "DirectEditorProps" section under the "plugins" heading. It was previously broken and exposing the Markdown syntax on the rendered version:

![image](https://user-images.githubusercontent.com/3069/140557077-dcd3c12b-a6c0-4ae1-94a3-89bdad5772b6.png)

Thank you for maintaining this project ❤️ 