### PR TITLE
feat (Widget): Add a destroy function to Decoration.widget

### DIFF
--- a/src/decoration.js
+++ b/src/decoration.js
@@ -14,7 +14,11 @@ class WidgetType {
 
   map(mapping, span, offset, oldOffset) {
     let {pos, deleted} = mapping.mapResult(span.from + oldOffset, this.side < 0 ? -1 : 1)
-    return deleted ? null : new Decoration(pos - offset, pos - offset, this)
+    if (deleted) {
+      this.destroy()
+      return null
+    }
+    return new Decoration(pos - offset, pos - offset, this)
   }
 
   valid() { return true }
@@ -24,6 +28,10 @@ class WidgetType {
       (other instanceof WidgetType &&
        (this.spec.key && this.spec.key == other.spec.key ||
         this.toDOM == other.toDOM && compareObjs(this.spec, other.spec)))
+  }
+
+  destroy () {
+    if (this.spec.destroy) this.spec.destroy()
   }
 }
 

--- a/src/decoration.js
+++ b/src/decoration.js
@@ -160,6 +160,10 @@ export class Decoration {
   //     key are interchangeable—if widgets differ in, for example,
   //     the behavior of some event handler, they should get
   //     different keys.
+  //    
+  //     destroy:: ?()
+  //     Called when the widget decoration is removed as a result of
+  //     mapping
   static widget(pos, toDOM, spec) {
     return new Decoration(pos, pos, new WidgetType(toDOM, spec))
   }

--- a/src/decoration.js
+++ b/src/decoration.js
@@ -14,11 +14,7 @@ class WidgetType {
 
   map(mapping, span, offset, oldOffset) {
     let {pos, deleted} = mapping.mapResult(span.from + oldOffset, this.side < 0 ? -1 : 1)
-    if (deleted) {
-      this.destroy()
-      return null
-    }
-    return new Decoration(pos - offset, pos - offset, this)
+    return deleted ? null : new Decoration(pos - offset, pos - offset, this)
   }
 
   valid() { return true }

--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -526,6 +526,11 @@ class WidgetViewDesc extends ViewDesc {
     return mutation.type != "selection" || this.widget.spec.ignoreSelection
   }
 
+  destroy() {
+    this.widget.destroy()
+    super.destroy()
+  }
+
   get domAtom() { return true }
 }
 


### PR DESCRIPTION
Adds a `destroy` method to widget decorations per discussion here:

https://discuss.prosemirror.net/t/unmounting-a-decoration-widget-created-with-react/3050/6