### PR TITLE
remove class attribute if classList is empty

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -1038,6 +1038,8 @@ function patchAttributes(dom, prev, cur) {
       dom.classList.remove(prevList[i])
     for (let i = 0; i < curList.length; i++) if (prevList.indexOf(curList[i]) == -1)
       dom.classList.add(curList[i])
+    if (dom.classList.length == 0)
+      dom.removeAttribute("class")
   }
   if (prev.style != cur.style) {
     if (prev.style) {


### PR DESCRIPTION
Not really a bug, but when all the class names of `prev` are removed and class names of `curr` is empty, there is an empty class attribute on the resulting outputted DOM.

https://github.com/ueberdosis/tiptap/issues/2126