### PR TITLE
Detect key events in code tag in domObserver

### DIFF
--- a/src/domchange.js
+++ b/src/domchange.js
@@ -119,7 +119,7 @@ export function readDOMChange(view, from, to, typeOver, addedNodes) {
         !view.composing && !(parse.sel && parse.sel.anchor != parse.sel.head)) {
       change = {start: sel.from, endA: sel.to, endB: sel.to}
     } else if ((browser.ios && view.lastIOSEnter > Date.now() - 225 || browser.android) &&
-               addedNodes.some(n => n.nodeName == "DIV" || n.nodeName == "P") &&
+               addedNodes.some(n => n.nodeName == "DIV" || n.nodeName == "P" || n.nodeName == "CODE") &&
                view.someProp("handleKeyDown", f => f(view, keyEvent(13, "Enter")))) {
       view.lastIOSEnter = 0
       return
@@ -164,7 +164,7 @@ export function readDOMChange(view, from, to, typeOver, addedNodes) {
   // If this looks like the effect of pressing Enter (or was recorded
   // as being an iOS enter press), just dispatch an Enter key instead.
   if (((browser.ios && view.lastIOSEnter > Date.now() - 225 &&
-        (!inlineChange || addedNodes.some(n => n.nodeName == "DIV" || n.nodeName == "P"))) ||
+        (!inlineChange || addedNodes.some(n => n.nodeName == "DIV" || n.nodeName == "P" || n.nodeName == "CODE"))) ||
        (!inlineChange && $from.pos < parse.doc.content.size &&
         (nextSel = Selection.findFrom(parse.doc.resolve($from.pos + 1), 1, true)) &&
         nextSel.head == $to.pos)) &&


### PR DESCRIPTION
We currently have a `code block` node that under the hood uses a `code` tag instead of a `p` tag for better syntax highlighting. We were noticing on mobile that if you hit enter within the code block it would delete all the text after the place where the "Enter" was done. 

I believe this will fix the issue but also not sure if it is the best approach. I don't think on our end we are able to change to a `p` tag now and must stick with `code`. 

Have attached some videos to help show the issue. This is done on the iOS simulator BTW

https://user-images.githubusercontent.com/13476523/142981409-4bdbd18d-2362-4f5e-8590-4fe674ee676c.mov

https://user-images.githubusercontent.com/13476523/142981414-e9ed5b88-be36-4f31-913d-ac320a44e956.mov




