### PR TITLE
feat: support `preserveWhitespace` in `Node.spec` to avoid dropping `newline`

### DIFF
--- a/src/domchange.js
+++ b/src/domchange.js
@@ -39,7 +39,7 @@ function parseBetween(view, from_, to_) {
     topOpen: true,
     from: fromOffset,
     to: toOffset,
-    preserveWhitespace: $from.parent.type.spec.code ? "full" : true,
+    preserveWhitespace: $from.parent.type.spec.code ? "full" : $from.parent.type.spec.preserveWhitespace || true,
     editableContent: true,
     findPositions: find,
     ruleFromNode,


### PR DESCRIPTION
https://codesandbox.io/s/prosemirror-forked-ziz0y?file=/src/index.js

As the demo shows, when typing in the `paragrph`.

All `\n` will be deleted, only `spec.code` can work.

But `code` can be used in other [situations](https://github.com/ProseMirror/prosemirror-commands/blob/master/src/commands.js#L229),  I think it would be better to support `preserveWhitespace` in `Node.spec`.

(If you can take my advice, I think I should also further update the code of `prosemirror-model`)

Is there a better solution or idea? I will be very grateful for that.