### PR TITLE
Opt out of drag selection delay in Safari

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -42,7 +42,10 @@ export function selectionToDOM(view, force) {
 
   if (!editorOwnsSelection(view)) return
 
-  if (!force && view.mouseDown && view.mouseDown.allowDefault) {
+  // The delayed drag selection causes issues with Cell Selections
+  // in Safari. And the drag selection delay is to workarond issues
+  // which only present in Chrome.
+  if (!force && view.mouseDown && view.mouseDown.allowDefault && browser.chrome) {
     let domSel = view.root.getSelection(), curSel = view.domObserver.currentSelection
     if (domSel.anchorNode && isEquivalentPosition(domSel.anchorNode, domSel.anchorOffset,
                                                   curSel.anchorNode, curSel.anchorOffset)) {


### PR DESCRIPTION
FIX: In Safari the drag selection delay introduced in prosemirror-view@1.19.2 (via ProseMirror/prosemirror-view@885258b) causes issues with Cell Selections (from the prosemirror-tables plugin).

The drag selection delay was introduced to resolve issues which were only present in chrome, so this change opts out of the drag selection delay for non chrome browsers.

This resolves https://github.com/ProseMirror/prosemirror/issues/1152