### PR TITLE
Return pos if descObj.parent is null

### DIFF
--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -637,6 +637,7 @@ class NodeViewDesc extends ViewDesc {
       // own position)
       if (!descObj) return pos
       if (descObj.parent) return descObj.parent.posBeforeChild(descObj)
+      return pos
     }, outerDeco, innerDeco)
 
     let dom = spec && spec.dom, contentDOM = spec && spec.contentDOM


### PR DESCRIPTION
In the example at https://tiptap.dev/api/nodes/task-item if you try to click the checkbox to toggle the todo item, you get a console error message:
```
Uncaught RangeError: Index 1 out of range for <taskList(taskItem(paragraph("A list item")), taskItem(paragraph("And another one")))>
    at F.child (vendor.248662a3.js:5:26763)
    at F.findIndex (vendor.248662a3.js:5:27448)
    at Me.nodeAt (vendor.248662a3.js:5:40931)
    at index.8f971c3d.js:1:2515
    at tabindex.0101c1e1.js:3:1741
    at Object.command (tabindex.0101c1e1.js:3:24344)
    at HTMLInputElement.<anonymous> (index.8f971c3d.js:1:2476)
```

Looking into this, it looks like descObj exists, but descObj.parent is null, so the function returns nothing. When I changed the return value to `pos`, it started working again.