### PR TITLE
Add empty alt attribute to img hack nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -428,6 +428,7 @@ function updateCursorWrapper(view) {
     let dom = document.createElement("img")
     dom.className = "ProseMirror-separator"
     dom.setAttribute("mark-placeholder", "true")
+    dom.setAttribute("alt", "")
     view.cursorWrapper = {dom, deco: Decoration.widget(view.state.selection.head, dom, {raw: true, marks: view.markCursor})}
   } else {
     view.cursorWrapper = null

--- a/src/viewdesc.js
+++ b/src/viewdesc.js
@@ -1267,7 +1267,10 @@ class ViewTreeUpdater {
       this.index++
     } else {
       let dom = document.createElement(nodeName)
-      if (nodeName == "IMG") dom.className = "ProseMirror-separator"
+      if (nodeName == "IMG") {
+        dom.className = "ProseMirror-separator"
+        dom.alt = ""
+      }
       if (nodeName == "BR") dom.className = "ProseMirror-trailingBreak"
       this.top.children.splice(this.index++, 0, new TrailingHackViewDesc(this.top, nothing, dom, null))
       this.changed = true


### PR DESCRIPTION
Currently, these are read as "graphic" by screen readers when present