### PR TITLE
Fix typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -643,7 +643,7 @@ function checkStateComponent(plugin) {
 
 // DirectEditorProps:: interface extends EditorProps
 //
-// The props object given directly to the editor view supports two
+// The props object given directly to the editor view supports some
 // fields that can't be used in plugins:
 //
 //   state:: EditorState


### PR DESCRIPTION
`DirectEditorProps` includes `plugins` since [this commit](https://github.com/ProseMirror/prosemirror-view/commit/ffd8f3a8659ec7ae0ddeda81c31131d22d7b9536#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R637), so it includes three fields now. 