### PR TITLE
Only flush the selection when the editor view has focus

### DIFF
--- a/src/domobserver.js
+++ b/src/domobserver.js
@@ -1,6 +1,6 @@
 import browser from "./browser"
 import {domIndex, isEquivalentPosition} from "./dom"
-import {hasFocusAndSelection, hasSelection, selectionToDOM} from "./selection"
+import {hasFocusAndSelection, selectionToDOM} from "./selection"
 
 const observeOptions = {
   childList: true,
@@ -145,7 +145,7 @@ export class DOMObserver {
     }
 
     let sel = this.view.root.getSelection()
-    let newSel = !this.suppressingSelectionUpdates && !this.currentSelection.eq(sel) && hasSelection(this.view) && !this.ignoreSelectionChange(sel)
+    let newSel = !this.suppressingSelectionUpdates && !this.currentSelection.eq(sel) && hasFocusAndSelection(this.view) && !this.ignoreSelectionChange(sel)
 
     let from = -1, to = -1, typeOver = false, added = []
     if (this.view.editable) {


### PR DESCRIPTION
Just as 94a7758 accounts for cases where the editor blurs without losing
the selection, account for the corresponding state when flushing wherein
the editor has the selection but not the focus.

If the editor view does not have focus, then it will set the selection
when it regains focus.