### PR TITLE
Make the `plugins` field in `DirectEditorProps` optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -649,7 +649,7 @@ function checkStateComponent(plugin) {
 //   state:: EditorState
 //   The current state of the editor.
 //
-//   plugins:: [Plugin]
+//   plugins:: ?[Plugin]
 //   A set of plugins to use in the view, applying their [plugin
 //   view](#state.PluginSpec.view) and
 //   [props](#state.PluginSpec.props). Passing plugins with a state


### PR DESCRIPTION
Fix https://github.com/ProseMirror/prosemirror/issues/1265 