### PR TITLE
Add CSS exports to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./style/prosemirror.css": {
+      "import": "./style/prosemirror.css",
+      "require": "./style/prosemirror.css"
+    }
   },
   "sideEffects": false,
   "style": "style/prosemirror.css",


### PR DESCRIPTION
Certain bundlers such as vite require that es module packages include all exports in the package.json, including CSS imports. 