### PR TITLE
Fix some types

### DIFF
--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -182,6 +182,8 @@ export class Decoration {
     /// Called when the widget decoration is removed as a result of
     /// mapping
     destroy?: (node: DOMNode) => void
+
+    [key: string]: any
   }): Decoration {
     return new Decoration(pos, pos, new WidgetType(toDOM, spec))
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -537,7 +537,7 @@ export interface EditorProps {
   /// `preventDefault` yourself (or not, if you want to allow the
   /// default behavior).
   handleDOMEvents?: {
-    [event in string]: (view: EditorView, event: DOMEventMap[event]) => boolean | void
+    [event in keyof DOMEventMap]?: (view: EditorView, event: DOMEventMap[event]) => boolean | void
   }
 
   /// Called when the editor receives a `keydown` event.
@@ -579,7 +579,7 @@ export interface EditorProps {
   /// Called when something is dropped on the editor. `moved` will be
   /// true if this drop moves from the current selection (which should
   /// thus be deleted).
-  handleDrop?: (view: EditorView, event: MouseEvent, slice: Slice, moved: boolean) => boolean | void
+  handleDrop?: (view: EditorView, event: DragEvent, slice: Slice, moved: boolean) => boolean | void
 
   /// Called when the view, after updating its state, tries to scroll
   /// the selection into view. A handler function may return false to
@@ -672,7 +672,7 @@ export interface EditorProps {
 
   /// A set of [document decorations](#view.Decoration) to show in the
   /// view.
-  decorations?: (state: EditorState) => DecorationSource | null
+  decorations?: (state: EditorState) => DecorationSource | null | undefined
 
   /// When this returns false, the content of the view is not directly
   /// editable.


### PR DESCRIPTION
1. For `__endComposition`, I can't find why it can't be compiled if export its type. **Need help!!!**

2. Allow custom attrs for Decoration.widget's spec

    In [uploading image case](https://prosemirror.net/examples/upload/), we need `id` property for the widget's spec. If I want to show the upload progress, I also need add `progress` property to spec for storing the DOM which will show the progress data.

3. Fix type for `decorations`, add undefined type, because `pluginKey.getState` returns `PluginState | undefined`.

    ```ts
    new Plugin({
      ...
      props: {
        decorations(state) {
          return pluginKey.getState(state);
        },
      },
    });
    ```
