### PR TITLE
Mark prosemirror.css file as a module with side-effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "./style/prosemirror.css": "./style/prosemirror.css"
   },
-  "sideEffects": false,
+  "sideEffects": ["./style/prosemirror.css"],
   "style": "style/prosemirror.css",
   "license": "MIT",
   "maintainers": [


### PR DESCRIPTION
This fix is required to import `prosemirror.css` like this:
```
import "prosemirror-view/style/prosemirror.css";
```
... and bundle styles into external css files using `mini-css-extract-plugin`.

Temporary workaround (webpack config):
```
  module: {
    rules: [
      {
        test: /\.css$/,
        include: path.resolve(
          __dirname,
          "node_modules/prosemirror-view/style/prosemirror.css",
        ),
        sideEffects: true,
      },
    ],
  },
```

References/explanation:

- https://github.com/webpack-contrib/mini-css-extract-plugin/issues/102#issuecomment-384947142
- https://webpack.js.org/guides/tree-shaking/#clarifying-tree-shaking-and-sideeffects