### PR TITLE
fix: drag scrollbar should not trigger click events

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -369,6 +369,7 @@ class MouseDown {
     let pos: {pos: number, inside: number} | null = this.pos
     if (this.view.state.doc != this.startDoc) pos = this.view.posAtCoords(eventCoords(event))
 
+    this.updateAllowDefault(event)
     if (this.allowDefault || !pos) {
       setSelectionOrigin(this.view, "pointer")
     } else if (handleSingleClick(this.view, pos.pos, pos.inside, event, this.selectNode)) {
@@ -395,11 +396,15 @@ class MouseDown {
   }
 
   move(event: MouseEvent) {
-    if (!this.allowDefault && (Math.abs(this.event.x - event.clientX) > 4 ||
-                               Math.abs(this.event.y - event.clientY) > 4))
-      this.allowDefault = true
+    this.updateAllowDefault(event)
     setSelectionOrigin(this.view, "pointer")
     if (event.buttons == 0) this.done()
+  }
+
+  updateAllowDefault(event: MouseEvent) {
+    if (!this.allowDefault && (Math.abs(this.event.x - event.clientX) > 4 ||
+      Math.abs(this.event.y - event.clientY) > 4))
+        this.allowDefault = true
   }
 }
 


### PR DESCRIPTION
Current behavior: Drag the scrollbar and release, click event is fired.
Expected behavior: Click event should not fire in this case.

Demo to reproduce the issue: [Glitch](https://glitch.com/edit/#!/kind-wiry-board).
Screen Recording: [Video](https://user-images.githubusercontent.com/4216856/177933327-f1cc6c5f-eccf-45d5-9d25-1cf67f786d26.mov).

Reason: Browser does not fire`mousemove` event when the user is dragging the scrollbar. [Demo](https://vivaxy.github.io/examples/web-api/mouse-event/).

Solution: Update `allowDefault` when `mouseup`.