### PR TITLE
Improved `EditorProps` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -528,7 +528,7 @@ export interface DOMEventMap extends HTMLElementEventMap {
 /// searching through the plugins (in order of appearance) until one of
 /// them returns true. For some props, the first plugin that yields a
 /// value gets precedence.
-export interface EditorProps {
+export interface EditorProps<ThisType = "default"> {
   /// Can be an object mapping DOM event type names to functions that
   /// handle them. Such functions will be called before any handling
   /// ProseMirror does of events fired on the editable DOM element.
@@ -541,7 +541,7 @@ export interface EditorProps {
   }
 
   /// Called when the editor receives a `keydown` event.
-  handleKeyDown?: (view: EditorView, event: KeyboardEvent) => boolean | void
+  handleKeyDown?: (this: ThisType extends "default" ? this : ThisType, view: EditorView, event: KeyboardEvent) => boolean | void
 
   /// Handler for `keypress` events.
   handleKeyPress?: (view: EditorView, event: KeyboardEvent) => boolean | void


### PR DESCRIPTION
Hi there,

At the moment this is just a proof-of-concept. When following the documentation [example for creating an upload image plugin](https://prosemirror.net/examples/upload/), I found typescript complaining for the `placeholderPlugin` on this line:

```ts
  },
  props: {
    decorations(state) { return this.getState(state) }
  }
})
```

The issue is that, here, `this` is typed as belonging to the props object (which only has one property: `decorations`). [Looking at the source code](https://github.com/ProseMirror/prosemirror-state/blob/master/src/plugin.ts#L11), I can see that `props` is typed as expecting the `EditorProps` interface and that, internally, all methods defined in `Plugin#props` receive the `Plugin` object as their `this` argument. So the typing here is currently a little off and I'm wondering if you'd accept a PR to fix the typing of `EditorProps` to accept an optional `ThisType` type argument. 

This PR contains a small example of what I mean. Currently, I've only changed the minimum amount to demonstrate what I'm talking about.

This would allow the `Plugin` class to define its `readonly props` property as `EditorProps<this>` and receive proper typing of `this` in the example code (as well as other code, obviously).

E.g. [simple typescript playground](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgKIBNhgPZQApTYAOAzgDwAqAFsCRQJ5EoC8yAROhPAK4A2YbAHzIA3gChkyTglxwwwbCBIB+AFzIAFGBol11WgybIIAD0gh0Jdpx782yZcm21kenYYgAaZCTByI6gBKEDJQ6GS+UKAA5t5wIPSCAJTIzMIAbtjA6ADcYgC+YmIIvHAkVgCy9Hi83NGgZDV1oADKfpCpyPGJohLIRISkAITqGFi4BMTkziSCeX3REGBt-hpw6t0pIoWFxYq+yIosyCAQAO7IVU31IBpJ80cAdANTneKS0rLy+xq+-lt9SRQJbcKAgJw6R6LZbtCC-WH3Pr5TwFMRAA)

```ts
export class Plugin<PluginState = any> {
  /* ...other stuff */

  readonly props: EditorProps<this> = {}

  /* ...other stuff */
}
```