### PR TITLE
fix safari coordsAtPos in code block

### DIFF
--- a/src/domcoords.ts
+++ b/src/domcoords.ts
@@ -341,7 +341,7 @@ export function coordsAtPos(view: EditorView, pos: number, side: number): Rect {
       else if (side >= 0 && offset == node.nodeValue!.length) { from--; takeSide = 1 }
       else if (side < 0) { from-- }
       else { to ++ }
-      return flattenV(singleRect(textRange(node as Text, from, to), takeSide), takeSide < 0)
+      return flattenV(singleRect(textRange(node as Text, from, to), 1), takeSide < 0)
     }
   }
 


### PR DESCRIPTION
fix safari reporting wrong coordsAtPos in code block when using up/down arrow

before
![before](https://user-images.githubusercontent.com/110001519/181420332-3f47142f-f7f8-41fd-a1eb-1544a82acd3d.gif)

after
![after](https://user-images.githubusercontent.com/110001519/181420637-42b27328-759b-4dde-a03b-1fbbe6a977fd.gif)

