### PR TITLE
Use previous selection when focus origins from key event

### DIFF
--- a/src/domchange.ts
+++ b/src/domchange.ts
@@ -80,7 +80,7 @@ export function readDOMChange(view: EditorView, from: number, to: number, typeOv
   if (from < 0) {
     let origin = view.input.lastSelectionTime > Date.now() - 50 ? view.input.lastSelectionOrigin : null
     let newSel = selectionFromDOM(view, origin)
-    if (newSel && !view.state.selection.eq(newSel)) {
+    if (origin && newSel && !view.state.selection.eq(newSel)) {
       let tr = view.state.tr.setSelection(newSel)
       if (origin == "pointer") tr.setMeta("pointer", true)
       else if (origin == "key") tr.scrollIntoView()


### PR DESCRIPTION
Selection should be restored to its previous state when using tab to navigate
a page with ProseMirror and other focusable elements with selection (inputs).

This is similar to how textareas work.

Note: While it's possible to create a workaround outside of prosemirror-view by saving the selection and restoring it before/after focus, it does not seem to be a way to avoid scroll jumps when the selection is further down in the document.

The input focus handler restores the previous selection (and DOM selection) already, so ignoring focus when origin is unknown (originated outside of the editor and not via pointer click) makes it restore the previous selection correctly without causing scroll jumps.