### PR TITLE
Add workaround for IE focusing nodes inside contenteditable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,21 @@ export class EditorView {
 
   /// Query whether the view has focus.
   hasFocus() {
+    // Work around IE not handling focus correctly if resize handles are shown.
+    // If the cursor is inside an element with resize handles, activeElement
+    // will be that element instead of this.dom.
+    if (browser.ie) {
+      // If activeElement is within this.dom, and there are no other elements
+      // setting `contenteditable` to false in between, treat it as focused.
+      let node = this.root.activeElement
+      if (node == this.dom) return true
+      if (!node || !this.dom.contains(node)) return false
+      while (node && this.dom != node && this.dom.contains(node)) {
+        if ((node as HTMLElement).contentEditable == 'false') return false
+        node = node.parentElement
+      }
+      return true
+    }
     return this.root.activeElement == this.dom
   }
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -181,7 +181,7 @@ export function selectionBetween(view: EditorView, $anchor: ResolvedPos, $head: 
 }
 
 export function hasFocusAndSelection(view: EditorView) {
-  if (view.editable && view.root.activeElement != view.dom) return false
+  if (view.editable && !view.hasFocus()) return false
   return hasSelection(view)
 }
 


### PR DESCRIPTION
In IE, if you have a DOM node that is showing the resize handles (this apparently happens when IE's internal [hasLayout](https://stackoverflow.com/questions/3603050/remove-resize-handles-and-border-from-elements-with-contenteditable) property is true for the node) and the cursor is inside that node, IE will report **it** as `document.activeElement` rather than the element that has `contenteditable` set on it.

This ends up causing `prosemirror-view` to not update the selection and a bunch of other weird behavior when the cursor is moved inside one of these elements, as `hasFocusAndSelection`  reports `false` in this case.

One symptom of this -- using (e.g.) `prosemirror-tables`, if you click inside a table cell and press "Enter', the newline will be inserted at the beginning of the document (or wherever your last cursor position was) instead. I've got a demo repo set up to compile for IE11 to showcase this: https://github.com/scq/prosemirror-ie11-test