### PR TITLE
fix domSel.collapse error in jest

### DIFF
--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -417,7 +417,7 @@ export class ViewDesc {
     // browsers support it yet.
     let domSelExtended = false
     if ((domSel.extend || anchor == head) && !brKludge) {
-      domSel.collapse(anchorDOM.node, anchorDOM.offset)
+      if (typeof domSel.collapse == "function") domSel.collapse(anchorDOM.node, anchorDOM.offset)
       try {
         if (anchor != head) domSel.extend(headDOM.node, headDOM.offset)
         domSelExtended = true


### PR DESCRIPTION
this PR is fixing a type error issue that i encountered when rendering the editor in jest tests.

### background

i'm using prosemirror via [@tiptap/react](https://www.npmjs.com/package/@tiptap/react). when trying to render the text editor component in tests using testing-library and jest test runner, the following happens:

1. the first test passes
2. the second test throws the error: `TypeError: domSel.collapse is not a function`

this could be an issue in my project's configuration or something on tiptap's side. in that case any suggestions on how to solve or report it would be appreciated.

note that the error only happens if i pass `autofocus` as true to the Editor's constructor, though i doubt this info will be useful here, as it's likely related to tiptap.

### PR info

i found that double-checking that `domSel.collapse` is indeed a function before trying to call it, fixes the issue. this PR does just that.