### PR TITLE
fix(clipboard-readHTML-windows): Fix readHTML issue on windows

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -202,6 +202,8 @@ function detachedDoc() {
 function readHTML(html: string) {
   let metas = /^(\s*<meta [^>]*>)*/.exec(html)
   if (metas) html = html.slice(metas[0].length)
+  const fragments = html.match(/<!--StartFragment-->(.*)<!--EndFragment-->/); // for windows
+  if (fragments) html = fragments[1]
   let elt = detachedDoc().createElement("div")
   let firstTag = /<([a-z][^>\s]+)/i.exec(html), wrap
   if (wrap = firstTag && wrapMap[firstTag[1].toLowerCase()])


### PR DESCRIPTION
Hi marijnh,
On mac,the copied data looks like:
`<meta charset='utf-8'><table data-pm-slice="1 1 -2 []"><tbody><tr><td class="PROSEMIRROR_TABLE_TD_CLS" align="left"><p>123</p></td></tr><tr><td class="PROSEMIRROR_TABLE_TD_CLS" align="left"><p>123</p></td></tr></tbody></table>`
However,on windows,the data looks like:
`<html><body><!--StartFragment--><table data-pm-slice="1 1 -2 []"><tbody><tr><td class="PROSEMIRROR_TABLE_TD_CLS" align="left"><p>123</p></td></tr><tr><td class="PROSEMIRROR_TABLE_TD_CLS" align="left"><p>123</p></td></tr></tbody></table><!--EndFragment--></body></html>`
This is the problem and the solution is included in this pr.
Thanks !