### PR TITLE
FIX: Keep multiple line breaks when pasting text

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -55,7 +55,7 @@ export function parseFromClipboard(view: EditorView, text: string, html: string 
       let marks = $context.marks()
       let {schema} = view.state, serializer = DOMSerializer.fromSchema(schema)
       dom = document.createElement("div")
-      text.split(/(?:\r\n?|\n)+/).forEach(block => {
+      text.split(/(?:\r\n?|\n)/).forEach(block => {
         let p = dom!.appendChild(document.createElement("p"))
         if (block) p.appendChild(serializer.serializeNode(schema.text(block, marks)))
       })


### PR DESCRIPTION
when paste text from bear editor: https://bear.app/

<img width="169" alt="image" src="https://user-images.githubusercontent.com/17960084/196874019-80c57c0d-7c98-41f6-bac7-1ef640f8ec60.png">



content: `Text\n\nText`

browser contenteditable show:
```
Text

Text
```

<img width="552" alt="image" src="https://user-images.githubusercontent.com/17960084/196872919-56f64d3e-6428-4774-912c-29524bf0b1c1.png">


but prosemirror editor show:
```
Text
Text
```

<img width="748" alt="image" src="https://user-images.githubusercontent.com/17960084/196873136-a0fa0b17-b75f-4e69-b55b-8e9a426fb9fe.png">


so need to keep multiple line breaks

