### PR TITLE
Fix composition after nodeview with mark(inclusive is false) will get…

### DIFF
--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -791,6 +791,17 @@ export class NodeViewDesc extends ViewDesc {
 
     // Patch up this.children to contain the composition view
     this.children = replaceNodes(this.children, pos, pos + text.length, view, desc)
+    // Force re-create markdesc dom to prevent renderDesc remove composition view
+    const changeDescIdx = new Set<number>();
+    this.children.forEach((desc, idx) => {
+      if (changeDescIdx.has(idx) || !(desc instanceof MarkViewDesc)) return
+      if (idx > 0 && this.children[idx - 1] instanceof CompositionViewDesc) changeDescIdx.add(idx)
+      if (idx < this.children.length - 1 && this.children[idx + 1] instanceof CompositionViewDesc) changeDescIdx.add(idx)
+    })
+    changeDescIdx.forEach((idx) => {
+      const markDesc = this.children[idx] as MarkViewDesc;
+      this.children[idx] = markDesc.slice(0, markDesc.posAtEnd - markDesc.posAtStart, view)
+    })
   }
 
   // If this desc must be updated to match the given node decoration,


### PR DESCRIPTION
Current behavior: In the nodes on the right side with mark (mark inclusive attribute is false) perform the IME input will cause an exception is thrown, and the input character will disappear。

Expected behavior: The words entered by the IME procedure can be displayed to the right of the node without throwing an exception。

Demo to reproduce the issue: [Glitch](https://glitch.com/edit/#!/spotty-octagonal-salt).
Screen Recording: ![1](https://user-images.githubusercontent.com/9218553/210798598-b935588e-28c8-4f73-b531-718bf70c4aa2.gif).
Error Snapshot: <img src="https://user-images.githubusercontent.com/9218553/210798874-1ef9c480-cb03-4961-94f5-72a192da0aef.png" alt="" width="300"/>

Reason: When renderDescs renders MarkViewDesc's parent NodeViewDesc, MarkViewDesc's dom and CompositionViewDesc's dom point to the same node, The composition node was accidentally deleted during the subsequent MarkViewDesc render.

Solution: During Composition, the MarkViewDesc node around CompositionViewDesc is recreated to ensure that the DOM and contentDOM point to different nodes from the CompositionViewDesc