### PR TITLE
Can't input with composing when the first node in selection range isn't editable

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -443,6 +443,17 @@ function inOrNearComposition(view: EditorView, event: Event) {
   return false
 }
 
+function isHeadContentAtom(selection: Selection) {
+  let firstChild = selection.$from.nodeAfter;
+  while (firstChild) {
+    if (firstChild.isAtom && !firstChild.isText) {
+      return true;
+    }
+    firstChild = firstChild.firstChild
+  }
+  return false;
+}
+
 // Drop active composition after 5 seconds of inactivity on Android
 const timeoutComposition = browser.android ? 5000 : -1
 
@@ -475,6 +486,13 @@ editHandlers.compositionstart = editHandlers.compositionupdate = view => {
             offset = -1
           }
         }
+      }
+
+      // If selected as the first node in range isn't editable
+      // browser doesn't insert content when inputs with composing
+      // thus in this case proactively delete content 
+      if (!state.selection.empty && isHeadContentAtom(state.selection)) {
+        view.domSelection().deleteFromDocument()
       }
     }
     view.input.composing = true


### PR DESCRIPTION
If the attribute `contenteditable` of the first content in selection range is `false`, it can't input with composing.
<img width="720" alt="image" src="https://user-images.githubusercontent.com/17680884/211236734-12ea2745-bf1e-46be-b206-876e296ba16e.png">

It can be reproduced at [examples/schema](https://prosemirror.net/examples/schema/)

https://user-images.githubusercontent.com/17680884/211236509-584b9a4d-4e94-4083-b828-c1f2666b70fa.mov

The behavior is the same when the first content in selection range is `block` [code example](https://codesandbox.io/s/prosemirror-basic-example-with-parcel-forked-bttq0q?file=/src/index.js).

Try to solve this problem, if there is a better solution, please share your ideas, thanks!
