### PR TITLE
Prevent model selection synchronizing to DOMSelection during selection.

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -43,6 +43,7 @@ export class DOMObserver {
   currentSelection = new SelectionState
   onCharData: ((e: Event) => void) | null = null
   suppressingSelectionUpdates = false
+  lockDOMSelectionSync = false
 
   constructor(
     readonly view: EditorView,
@@ -132,7 +133,9 @@ export class DOMObserver {
       if (sel.focusNode && isEquivalentPosition(sel.focusNode, sel.focusOffset, sel.anchorNode!, sel.anchorOffset))
         return this.flushSoon()
     }
+    this.lockDOMSelectionSync = !!this.view.input.mouseDown
     this.flush()
+    this.lockDOMSelectionSync = false
   }
 
   setCurSelection() {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -64,7 +64,7 @@ export function selectionToDOM(view: EditorView, force = false) {
 
   if (view.cursorWrapper) {
     selectCursorWrapper(view)
-  } else {
+  } else if (!view.domObserver.lockDOMSelectionSync) {
     let {anchor, head} = sel, resetEditableFrom, resetEditableTo
     if (brokenSelectBetweenUneditable && !(sel instanceof TextSelection)) {
       if (!sel.$from.parent.inlineContent)


### PR DESCRIPTION
Current behavior: Now there are some selection issues that are bothering me, e.g.
A NodeView with margin(margin-left and margin-right), when select from NodeView's right to left,  the selection is collapsed accidentally.
![1](https://user-images.githubusercontent.com/9218553/219035264-7737e1ce-746a-40a7-8fd7-9b53f16802df.gif)

A NodeView that regardless of margin, when select from NodeView's right to left, and shuffling between text and NodeView, the anchor of the selection was be collapse to NodeView left. 
![1](https://user-images.githubusercontent.com/9218553/219035452-b6ef520d-1ad6-4a2e-8f5a-3dbe9c85b66e.gif)

A NodeView that has content in the schema but does not set with contentDOM, when select from NodeView's right to left, and shuffling between text and NodeView, the anchor of the selection was be collapse to NodeView left. 
![1](https://user-images.githubusercontent.com/9218553/219035739-9eefcea7-3551-4a05-88d6-ed15af8a1b68.gif)


Expected behavior: The selection should not be affected by the element style and "anchor" should be fixed while moving the "focus"


Through some experiments, I found that when I set the selection in the selectionChange callback triggered by mouse interaction, when the set selection is not the "legal" position considered by the browser, the browser may readjust the selection. Therefore, I boldly submitted a PR  -  In the callback of selectionChange triggered by mouse interaction, do not synchronize selection from model to DOM. I think there might be some unexpected effects, so I'm looking forward to your insight.

Demo to reproduce the issue: [Glitch](https://glitch.com/edit/#!/curse-organized-silicon).
