### PR TITLE
bugfix: avoid bug if domSelection is not displayed in the webpage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,7 @@ export class EditorView {
         // Chrome sometimes starts misreporting the selection, so this
         // tracks that and forces a selection reset when our update
         // did write to the node.
-        let chromeKludge = browser.chrome ? (this.trackWrites = this.domSelectionRange().focusNode) : null
+        let chromeKludge = browser.chrome ? (this.trackWrites = this.domSelectionRange()?.focusNode) : null
         if (redraw || !this.docView.update(state.doc, outerDeco, innerDeco, this)) {
           this.docView.updateOuterDeco([])
           this.docView.destroy()


### PR DESCRIPTION
Hello, during my work I use [Kendo Editor](https://www.npmjs.com/package/@progress/kendo-angular-editor) which use this component. It appear that from time to time on Chrome we have the following error `TypeError: Cannot read properties of null (reading 'focusNode')\n at EditorView.updateStateInner`.

I believe that this small change would prevent this bug.