### PR TITLE
FIX: Fix an issue with cursor jump in table cell

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -388,7 +388,7 @@ class MouseDown {
                 // (hidden) cursor is doesn't change the selection, and
                 // thus doesn't get a reaction from ProseMirror. This
                 // works around that.
-                (browser.chrome && !this.view.state.selection.visible &&
+                (browser.chrome && (!this.view.state.selection.visible || this.view.state.selection instanceof TextSelection) &&
                  Math.min(Math.abs(pos.pos - this.view.state.selection.from),
                           Math.abs(pos.pos - this.view.state.selection.to)) <= 2))) {
       updateSelection(this.view, Selection.near(this.view.state.doc.resolve(pos.pos)), "pointer")


### PR DESCRIPTION
@marijnh 
I encountered a problem when the user wants to choose a different cell and in condition that the previous one has some content. 

I also recorded a short gif demonstrating the problem 
![ezgif com-optimize](https://user-images.githubusercontent.com/14232040/225284794-42c7a250-8d62-4223-b42f-48ea81e7620b.gif)
 
and I also made a solution as part of this PR.  

P.S.
It may not be in line with the best practices of the whole lib but it can serve as an inspiration for a potential fix. Thanks in advance.

Stack: 

- browser: Google Chrome **Version 111.0.5563.64** 
- prosemirror-view- **1.30.2** 
- prosemirror-collab - **1.30.0** 
- prosemirror-tables - **1.2.5**