### PR TITLE
Use just created selection instead of view selection state in dragstart handler

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -632,13 +632,15 @@ handlers.dragstart = (view, _event) => {
   if (pos && pos.pos >= sel.from && pos.pos <= (sel instanceof NodeSelection ? sel.to - 1: sel.to)) {
     // In selection
   } else if (mouseDown && mouseDown.mightDrag) {
-    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, mouseDown.mightDrag.pos)))
+    sel = NodeSelection.create(view.state.doc, mouseDown.mightDrag.pos))
+    view.dispatch(view.state.tr.setSelection(sel)
   } else if (event.target && (event.target as HTMLElement).nodeType == 1) {
     let desc = view.docView.nearestDesc(event.target as HTMLElement, true)
     if (desc && desc.node.type.spec.draggable && desc != view.docView)
-      view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, desc.posBefore)))
+      sel = NodeSelection.create(view.state.doc, desc.posBefore))
+      view.dispatch(view.state.tr.setSelection(sel)
   }
-  let slice = view.state.selection.content(), {dom, text} = serializeForClipboard(view, slice)
+  let slice = sel.content(), {dom, text} = serializeForClipboard(view, slice)
   event.dataTransfer.clearData()
   event.dataTransfer.setData(brokenClipboardAPI ? "Text" : "text/html", dom.innerHTML)
   // See https://github.com/ProseMirror/prosemirror/issues/1156


### PR DESCRIPTION
Hi,
I am using ProseMirror within Lit components. In order to fit Lit mental model and lifecycle, we update the editor view based on the state during render:

```
  render() {
    this.view.updateState(this.edstate)
    return html`...`
```
However, while working on drag and drop, I've noticed that the default handler expects the "dispatch" calls to be synchronous. This means that `updateState` is expected to be called immediately, so that `view.state.selection` is up to date to the latest selection.

This forces us to also call `updateState` whenever we dispatch a transaction:
```ts
      dispatchTransaction: (tr) => {
        this.edstate = this.edstate.apply(tr);
        // important otherwise the view state will be stale immediately after a dispatch
        this.view.updateState(this.edstate)
      },
```

While I know the need to call `updateState` when dispatching is documented, this is still a bit unsettling to see code consider a dispatch to be synchronous and the state to be immediately up to date. Would this still work if I wanted to add more operations to the transaction? It's also a breach in the Lit component lifecycle, because now the view will update in-between render cycles.

This is a small PR mostly as an occasion to discuss this approach. This code should work even with an asynchronous dispatch, because it uses the new selection directly instead of the selection from the view state.