### PR TITLE
potential fix for recreatewrapper

### DIFF
--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -1244,6 +1244,9 @@ class ViewTreeUpdater {
           return true
         } else if (!locked && (updated = this.recreateWrapper(next, node, outerDeco, innerDeco, view, pos))) {
           this.top.children[this.index] = updated
+          updated.dirty = CONTENT_DIRTY
+          updated.updateChildren(view, pos + 1)
+          updated.dirty = NOT_DIRTY
           this.changed = true
           this.index++
           return true
@@ -1265,9 +1268,7 @@ class ViewTreeUpdater {
     wrapper.children = next.children
     next.children = []
     for (let ch of wrapper.children) ch.parent = wrapper
-    wrapper.dirty = CONTENT_DIRTY
-    wrapper.updateChildren(view, pos + 1)
-    wrapper.dirty = NOT_DIRTY
+   
     return wrapper
   }
 


### PR DESCRIPTION
Several users of my library reported issues after the latest `prosemirror-view` release.

e.g.: 
- https://github.com/TypeCellOS/BlockNote/issues/181
- https://github.com/TypeCellOS/BlockNote/issues/182 (includes a reproduction repo)

I dove into this issue, and I think a regression was introduced here: https://github.com/ProseMirror/prosemirror-view/commit/47be3c32b9fd2238a4bffd7435ada713cee64750

I think what's happening is that `updateChildren` relies on a "stable" parent / child hierarchy across nodes, but at the moment it's called, it's not "stable", because `this.top.children[this.index] = updated` hasn't executed yet.

I can confirm that this PR fixes the issue, but I'm not confident it's a root-cause fix or the best way to solve it, as I'm not too up to speed with the inner workings of `recreateWrapper` and `prosemirror-view`. Nevertheless, I hope this helps to fix / diagnose the issue!