### PR TITLE
Allow translation if contenteditable is set to false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -478,7 +478,7 @@ function computeDocDeco(view: EditorView) {
   let attrs = Object.create(null)
   attrs.class = "ProseMirror"
   attrs.contenteditable = String(view.editable)
-  attrs.translate = "no"
+  attrs.translate = view.editable ? "no" : "yes"
 
   view.someProp("attributes", value => {
     if (typeof value == "function") value = value(view.state)


### PR DESCRIPTION
Translate breaks prosemirror when someone begins editing (https://github.com/ProseMirror/prosemirror/issues/1074 was fixed by setting `translate=no` on the view).

We would like the already-rendered and uneditable content to be translatable, though (https://github.com/ueberdosis/tiptap/issues/3826).

This PR fixes https://github.com/ueberdosis/tiptap/issues/3826 by setting the `translate` property based on the `editable` property of the view. 