### PR TITLE
Don't delay handle*Click[On] handlers when none for higher click count defined

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -271,14 +271,24 @@ function forceDOMFlush(view: EditorView) {
 
 const selectNodeModifier: keyof MouseEvent = browser.mac ? "metaKey" : "ctrlKey"
 
+const hasDoubleClickHandlers = (view: EditorView): boolean => (
+  !!view.someProp("handleDoubleClick") || !!view.someProp("handleDoubleClickOn")
+  || !!view.someProp("handleTripleClick") || !!view.someProp("handleTripleClickOn")
+)
+
+const hasTripleClickHandlers = (view: EditorView): boolean => (
+  !!view.someProp("handleTripleClick") || !!view.someProp("handleTripleClickOn")
+)
+
 handlers.mousedown = (view, _event) => {
   let event = _event as MouseEvent
   view.input.shiftKey = event.shiftKey
   let flushed = forceDOMFlush(view)
   let now = Date.now(), type = "singleClick"
   if (now - view.input.lastClick.time < 500 && isNear(event, view.input.lastClick) && !event[selectNodeModifier]) {
-    if (view.input.lastClick.type == "singleClick") type = "doubleClick"
-    else if (view.input.lastClick.type == "doubleClick") type = "tripleClick"
+    if (view.input.lastClick.type == "singleClick" && 
+      (hasDoubleClickHandlers(view) || hasTripleClickHandlers(view))) type = "doubleClick"
+    else if (view.input.lastClick.type == "doubleClick" && hasTripleClickHandlers(view)) type = "tripleClick"
   }
   view.input.lastClick = {time: now, x: event.clientX, y: event.clientY, type}
 


### PR DESCRIPTION
First and foremost, thank you for a fantastic library! I don't have too much experience with TS and (modern) JS, so I'm sorry up front if I botched or completely misunderstood anything, and please _do_ shout 😅.

This patch is trying to address a following case:

I want to achieve a behavior where each consecutive single click on a node replaces it with the same node with boolean attribute flipped to the opposite value. In this particular case it's a checkbox node. At first I have defined an event handler in a following way:

```typescript
...
handleClickOn(view, _pos, node, nodePos) {
  const checkbox = taskSchema.nodes.checkbox;
  if (node.type === checkbox) {
    const tr = view.state.tr.replaceWith(nodePos, nodePos + 1, checkbox.create({ checked: !node.attrs.checked }))
    view.dispatch(tr);
  }
  return true;
}
...
```

While it's working correctly, it has an annoying property - the checkbox flips only every couple clicks when I click rapidly, which gives an impression of unresponsive UI. After some poking and digging, my understanding is that what's causing the slowdown is the logic detecting multiple clicks defined at https://github.com/ProseMirror/prosemirror-view/compare/master...zoldar:prosemirror-view:fix/dont-delay-click-handlers?expand=1#diff-cb8cbffa623ff0975389e7e8c315e69d5e10345239ffe2c9b4b7986a56ad95efR288.

My first workaround was attempting to reimplement it with `handleDOMEvents` in a following way:

```typescript
...
handleDOMEvents: {
  click: (view, event) => {
    const pos = view.posAtCoords(eventCoords(event));
    if (pos) {
      const checkbox = taskSchema.nodes.checkbox;
      const node = view.state.doc.nodeAt(pos.inside);
      const nodePos = pos.inside;
      if (node?.type === checkbox) {
        const tr = view.state.tr.replaceWith(nodePos, nodePos + 1, checkbox.create({ checked: !node.attrs.checked }))
        view.dispatch(tr);
      }
    }
    return true;
  }
},
...
```

It works a lot more responsively, but, for a change, it's selecting text in the inline node following it after clicking more than once quickly, for some reason - I might have very well done something horribly wrong here.

Anyway, then, I thought that perhaps a slight optimization to the handler routine could save me from resorting to that workaround?

Because for that particular editor I don't intend to define any double or triple click handlers any soon, I thought what if detection code considered whether there are handlers defined for respective events at all? The proposed patch is trying to make that detection a little bit "smarter" to avoid hogging consecutive quick clicks _when_ possible.

I have tested that branch against my little learning project and it _seems_ to behave. I have not found existing test cases for click handlers but maybe I missed something 😅 (I'm not even sure how a test for something like that would look).