### PR TITLE
Remove `<img />` hack for chrome

### DIFF
--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -1308,8 +1308,8 @@ class ViewTreeUpdater {
         !(lastChild instanceof TextViewDesc) ||
         /\n$/.test(lastChild.node.text!) ||
         (this.view.requiresGeckoHackNode && /\s$/.test(lastChild.node.text!))) {
-      // Avoid bugs in Safari's cursor drawing (#1165) and Chrome's mouse selection (#1152)
-      if ((browser.safari || browser.chrome) && lastChild && (lastChild.dom as HTMLElement).contentEditable == "false")
+      // Avoid bugs in Safari's cursor drawing (#1165)
+      if (browser.safari && lastChild && (lastChild.dom as HTMLElement).contentEditable == "false")
         this.addHackNode("IMG", parent)
       this.addHackNode("BR", this.top)
     }

--- a/test/webtest-selection.ts
+++ b/test/webtest-selection.ts
@@ -146,7 +146,7 @@ describe("EditorView", () => {
   })
 
   it("produces sensible screen coordinates in corner cases", () => {
-    let view = tempEditor({doc: doc(p("one", em("two", strong("three"), img), br(), code("foo")), p())})
+    let view = tempEditor({doc: doc(p("one", em("two", strong("three"), img), br(), code("foo"), br()), p())})
     return new Promise(ok => {
       setTimeout(() => {
         allPositions(view.state.doc).forEach(pos => {


### PR DESCRIPTION
which was added in 7e0ddfac008d31b9a74fe3245e61a606bf321ee5 (https://github.com/ProseMirror/prosemirror/issues/1152)

It seems like this workaround is no longer needed, and actually breaks the behaviour now.

The demo from that issue (https://unequaled-truthful-condition.glitch.me/) doesn't work on Chrome `119.0.6045.123 (Official Build) (arm64)`

This video shows the issue as it is now, and then I make the same fix in chrome as a local override and you can see it is fixed.


https://github.com/ProseMirror/prosemirror-view/assets/3259993/50573cc0-1b26-4db9-be25-220378670737

So this looks safe to remove?