### PR TITLE
Create unit tests for a decoration mapping bug

### DIFF
--- a/test/test-decoration-mapping.ts
+++ b/test/test-decoration-mapping.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import { Decoration, DecorationSet } from 'prosemirror-view';
-import { StepMap, Mapping } from 'prosemirror-transform';
+import { Transform } from 'prosemirror-transform';
 import { Node as PmNode } from 'prosemirror-model';
 import { doc, p, blockquote } from 'prosemirror-test-builder';
 
-type DecorationSetTestCase = { afterDoc: any, actionMapping: Mapping, undoMapping: Mapping };
+type DecorationSetTestCase = { afterActionDecos: DecorationSet, actionTr: Transform };
 describe('Decoration Set maps consistently with inserts', () => {
     const block1 = blockquote(p('Lorem <s1>ipsum<e1>'));
     const block2 = blockquote(p('dolor sit amet,'));
@@ -31,116 +31,63 @@ describe('Decoration Set maps consistently with inserts', () => {
 
     const beforeDecorationSet = getDecorations(beforeDoc);
 
-    /** Gets the node size of the new block associated with the provided tag */
-    const getNodeSizeFor = (afterDoc: PmNode, tag: string) => {
-        return afterDoc.resolve((afterDoc as any).tag[`${tag}`]).nodeAfter!.nodeSize;
-    };
-
     /** Build the set of test cases */
     const testCases = [] as DecorationSetTestCase[];
 
     // Test Case 0
     const afterDoc0 = doc(
         '<a0>', blockquote(p('test')),
-        '<a1>', blockquote(p('hello')),
         block1,
-        '<a2>', blockquote(p('test')),
-        '<a3>', blockquote(p('hello')),
+        '<a1>', blockquote(p('test')),
         block2,
-        '<a4>', blockquote(p('test')),
-        '<a5>', blockquote(p('hello')),
+        '<a2>', blockquote(p('test')),
         block3,
-        '<a6>', blockquote(p('test')),
-        '<a7>', blockquote(p('hello')),
+        '<a3>', blockquote(p('test')),
         block4,
-        '<a8>', blockquote(p('test')),
-        '<a9>', blockquote(p('hello')),
+        '<a4>', blockquote(p('test')),
         block5
     ) as any;
-    testCases.push({
-        afterDoc: afterDoc0,
-        actionMapping: new Mapping([
-            new StepMap([afterDoc0.tag.a0, 0, getNodeSizeFor(afterDoc0, 'a0')]),
-            new StepMap([afterDoc0.tag.a1, 0, getNodeSizeFor(afterDoc0, 'a1')]),
-            new StepMap([afterDoc0.tag.a2, 0, getNodeSizeFor(afterDoc0, 'a2')]),
-            new StepMap([afterDoc0.tag.a3, 0, getNodeSizeFor(afterDoc0, 'a3')]),
-            new StepMap([afterDoc0.tag.a4, 0, getNodeSizeFor(afterDoc0, 'a4')]),
-            new StepMap([afterDoc0.tag.a5, 0, getNodeSizeFor(afterDoc0, 'a5')]),
-            new StepMap([afterDoc0.tag.a6, 0, getNodeSizeFor(afterDoc0, 'a6')]),
-            new StepMap([afterDoc0.tag.a7, 0, getNodeSizeFor(afterDoc0, 'a7')]),
-            new StepMap([afterDoc0.tag.a8, 0, getNodeSizeFor(afterDoc0, 'a8')]),
-            new StepMap([afterDoc0.tag.a9, 0, getNodeSizeFor(afterDoc0, 'a9')])
-        ]),
-        undoMapping: new Mapping([
-            new StepMap([afterDoc0.tag.a8, getNodeSizeFor(afterDoc0, 'a8') + getNodeSizeFor(afterDoc0, 'a9'), 0]),
-            new StepMap([afterDoc0.tag.a6, getNodeSizeFor(afterDoc0, 'a6') + getNodeSizeFor(afterDoc0, 'a7'), 0]),
-            new StepMap([afterDoc0.tag.a4, getNodeSizeFor(afterDoc0, 'a4') + getNodeSizeFor(afterDoc0, 'a5'), 0]),
-            new StepMap([afterDoc0.tag.a2, getNodeSizeFor(afterDoc0, 'a2') + getNodeSizeFor(afterDoc0, 'a3'), 0]),
-            new StepMap([afterDoc0.tag.a0, getNodeSizeFor(afterDoc0, 'a0') + getNodeSizeFor(afterDoc0, 'a1'), 0])
-        ])
-    });
+    const actionTr = new Transform(beforeDoc);
+    actionTr.insert(afterDoc0.tag.a0, blockquote(p('test')));
+    actionTr.insert(afterDoc0.tag.a1, blockquote(p('test')));
+    actionTr.insert(afterDoc0.tag.a2, blockquote(p('test')));
+    actionTr.insert(afterDoc0.tag.a3, blockquote(p('test')));
+    actionTr.insert(afterDoc0.tag.a4, blockquote(p('test')));
+    testCases.push({ afterActionDecos: getDecorations(afterDoc0), actionTr });
 
     // Test Case 1
     const afterDoc1 = doc(
         '<a0>', blockquote(p('test')),
-        '<a1>', blockquote(p('hello')),
         block1,
         block2,
         block3,
-        '<a2>', blockquote(p('test')),
-        '<a3>', blockquote(p('hello')),
+        '<a1>', blockquote(p('test')),
         block4,
-        '<a4>', blockquote(p('test')),
-        '<a5>', blockquote(p('hello')),
+        '<a2>', blockquote(p('test')),
         block5
     ) as any;
-    testCases.push({
-        afterDoc: afterDoc1,
-        actionMapping: new Mapping([
-            new StepMap([afterDoc1.tag.a0, 0, getNodeSizeFor(afterDoc1, 'a0')]),
-            new StepMap([afterDoc1.tag.a1, 0, getNodeSizeFor(afterDoc1, 'a1')]),
-            new StepMap([afterDoc1.tag.a2, 0, getNodeSizeFor(afterDoc1, 'a2')]),
-            new StepMap([afterDoc1.tag.a3, 0, getNodeSizeFor(afterDoc1, 'a3')]),
-            new StepMap([afterDoc1.tag.a4, 0, getNodeSizeFor(afterDoc1, 'a4')]),
-            new StepMap([afterDoc1.tag.a5, 0, getNodeSizeFor(afterDoc1, 'a5')])
-        ]),
-        undoMapping: new Mapping([
-            new StepMap([afterDoc1.tag.a4, getNodeSizeFor(afterDoc1, 'a4') + getNodeSizeFor(afterDoc1, 'a5'), 0]),
-            new StepMap([afterDoc1.tag.a2, getNodeSizeFor(afterDoc1, 'a2') + getNodeSizeFor(afterDoc1, 'a3'), 0]),
-            new StepMap([afterDoc1.tag.a0, getNodeSizeFor(afterDoc1, 'a0') + getNodeSizeFor(afterDoc1, 'a1'), 0])
-        ])
-    });
+    var actionTr1 = new Transform(beforeDoc);
+    actionTr1.insert(afterDoc1.tag.a0, blockquote(p('test')));
+    actionTr1.insert(afterDoc1.tag.a1, blockquote(p('test')));
+    actionTr1.insert(afterDoc1.tag.a2, blockquote(p('test')));
+    testCases.push({ afterActionDecos: getDecorations(afterDoc1), actionTr: actionTr1 });
 
     // Test Case 2
     const afterDoc2 = doc(
         '<a0>', blockquote(p('test')),
-        '<a1>', blockquote(p('hello')),
         block1,
-        '<a2>', blockquote(p('test')),
-        '<a3>', blockquote(p('hello')),
+        '<a1>', blockquote(p('test')),
         block2,
         block3,
         block4,
-        '<a4>', blockquote(p('test')),
-        '<a5>', blockquote(p('hello')),
+        '<a2>', blockquote(p('test')),
         block5
     ) as any;
-    testCases.push({
-        afterDoc: afterDoc2,
-        actionMapping: new Mapping([
-            new StepMap([afterDoc2.tag.a0, 0, getNodeSizeFor(afterDoc2, 'a0')]),
-            new StepMap([afterDoc2.tag.a1, 0, getNodeSizeFor(afterDoc2, 'a1')]),
-            new StepMap([afterDoc2.tag.a2, 0, getNodeSizeFor(afterDoc2, 'a2')]),
-            new StepMap([afterDoc2.tag.a3, 0, getNodeSizeFor(afterDoc2, 'a3')]),
-            new StepMap([afterDoc2.tag.a4, 0, getNodeSizeFor(afterDoc2, 'a4')]),
-            new StepMap([afterDoc2.tag.a5, 0, getNodeSizeFor(afterDoc2, 'a5')])
-        ]),
-        undoMapping: new Mapping([
-            new StepMap([afterDoc2.tag.a4, getNodeSizeFor(afterDoc2, 'a4') + getNodeSizeFor(afterDoc2, 'a5'), 0]),
-            new StepMap([afterDoc2.tag.a2, getNodeSizeFor(afterDoc2, 'a2') + getNodeSizeFor(afterDoc2, 'a3'), 0]),
-            new StepMap([afterDoc2.tag.a0, getNodeSizeFor(afterDoc2, 'a0') + getNodeSizeFor(afterDoc2, 'a1'), 0])
-        ])
-    });
+    var actionTr2 = new Transform(beforeDoc);
+    actionTr2.insert(afterDoc2.tag.a0, blockquote(p('test')));
+    actionTr2.insert(afterDoc2.tag.a1, blockquote(p('test')));
+    actionTr2.insert(afterDoc2.tag.a2, blockquote(p('test')));
+    testCases.push({ afterActionDecos: getDecorations(afterDoc2), actionTr: actionTr2 });
 
     // Test Case 3
     const afterDoc3 = doc(
@@ -153,44 +100,31 @@ describe('Decoration Set maps consistently with inserts', () => {
         '<a2>', blockquote(p('hello')),
         block5
     ) as any;
-    testCases.push({
-        afterDoc: afterDoc3,
-        actionMapping: new Mapping([
-            new StepMap([afterDoc3.tag.a0, 0, getNodeSizeFor(afterDoc3, 'a0')]),
-            new StepMap([afterDoc3.tag.a1, 0, getNodeSizeFor(afterDoc3, 'a1')]),
-            new StepMap([afterDoc3.tag.a2, 0, getNodeSizeFor(afterDoc3, 'a2')])
-        ]),
-        undoMapping: new Mapping([
-            new StepMap([afterDoc3.tag.a4, getNodeSizeFor(afterDoc3, 'a2'), 0]),
-            new StepMap([afterDoc3.tag.a2, getNodeSizeFor(afterDoc3, 'a1'), 0]),
-            new StepMap([afterDoc3.tag.a0, getNodeSizeFor(afterDoc3, 'a0'), 0])
-        ])
-    });
+    const actionTr3 = new Transform(beforeDoc);
+    actionTr3.insert(afterDoc3.tag.a0, blockquote(p('hello')));
+    actionTr3.insert(afterDoc3.tag.a1, blockquote(p('hello')));
+    actionTr3.insert(afterDoc3.tag.a2, blockquote(p('hello')));
+    testCases.push({ afterActionDecos: getDecorations(afterDoc3), actionTr: actionTr3 });
 
-    testCases.forEach(({ afterDoc, actionMapping, undoMapping}: DecorationSetTestCase, i: number) => {
+    testCases.forEach(({ afterActionDecos, actionTr }: DecorationSetTestCase, i: number) => {
         it(`on action (test case ${i})`, () => {
-            const expectedAfterActionDecos = getDecorations(afterDoc);
 
-            let afterActionSet = beforeDecorationSet.map(actionMapping, afterDoc);
-            assert.deepEqual(afterActionSet.find(), expectedAfterActionDecos.find());
+            let afterActionSet = beforeDecorationSet.map(actionTr.mapping, actionTr.doc);
+            assert.deepEqual(afterActionSet.find(), afterActionDecos.find());
         });
 
         it(`on undo (test case ${i})`, () => {
-            const afterActionSet = getDecorations(afterDoc);
-
-            let afterUndoSet = afterActionSet.map(undoMapping, beforeDoc);
+            let afterUndoSet = afterActionDecos.map(actionTr.mapping.invert(), beforeDoc);
             assert.deepEqual(afterUndoSet.find(), beforeDecorationSet.find());
         });
 
         it(`on action and undo (test case ${i})`, () => {
-            const expectedAfterActionDecos = getDecorations(afterDoc);
-
             // Act 1 - apply action
-            let afterActionSet = beforeDecorationSet.map(actionMapping, afterDoc);
-            assert.deepEqual(afterActionSet.find(), expectedAfterActionDecos.find());
+            let afterActionSet = beforeDecorationSet.map(actionTr.mapping, actionTr.doc);
+            assert.deepEqual(afterActionSet.find(), afterActionDecos.find());
 
             // Act 2 - apply undo
-            let afterUndoSet = afterActionSet.map(undoMapping, beforeDoc);
+            let afterUndoSet = afterActionSet.map(actionTr.mapping.invert(), beforeDoc);
             assert.deepEqual(afterUndoSet.find(), beforeDecorationSet.find());
         });
     });

--- a/test/test-decoration-mapping.ts
+++ b/test/test-decoration-mapping.ts
@@ -1,0 +1,197 @@
+import assert from 'assert';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+import { StepMap, Mapping } from 'prosemirror-transform';
+import { Node as PmNode } from 'prosemirror-model';
+import { doc, p, blockquote } from 'prosemirror-test-builder';
+
+type DecorationSetTestCase = { afterDoc: any, actionMapping: Mapping, undoMapping: Mapping };
+describe('Decoration Set maps consistently with inserts', () => {
+    const block1 = blockquote(p('Lorem <s1>ipsum<e1>'));
+    const block2 = blockquote(p('dolor sit amet,'));
+    const block3 = blockquote(p('consectetur adipiscing elit,'));
+    const block4 = blockquote(p('sed do <s2>eiusmod<e2> tempor incididunt'));
+    const block5 = blockquote(p('ut labore et <s3>dolore<e3> magna aliqua.'));
+
+    const beforeDoc = doc(
+        block1,
+        block2,
+        block3,
+        block4,
+        block5
+    ) as any;
+
+    /** Get the set of expected decorations in the provided doc */
+    const getDecorations = (docWithDecos: any) => {
+        return DecorationSet.create(docWithDecos, [
+            Decoration.inline(docWithDecos.tag.s1, docWithDecos.tag.e1, {}),
+            Decoration.inline(docWithDecos.tag.s2, docWithDecos.tag.e2, {}),
+            Decoration.inline(docWithDecos.tag.s3, docWithDecos.tag.e3, {})
+        ]);
+    };
+
+    const beforeDecorationSet = getDecorations(beforeDoc);
+
+    /** Gets the node size of the new block associated with the provided tag */
+    const getNodeSizeFor = (afterDoc: PmNode, tag: string) => {
+        return afterDoc.resolve((afterDoc as any).tag[`${tag}`]).nodeAfter!.nodeSize;
+    };
+
+    /** Build the set of test cases */
+    const testCases = [] as DecorationSetTestCase[];
+
+    // Test Case 0
+    const afterDoc0 = doc(
+        '<a0>', blockquote(p('test')),
+        '<a1>', blockquote(p('hello')),
+        block1,
+        '<a2>', blockquote(p('test')),
+        '<a3>', blockquote(p('hello')),
+        block2,
+        '<a4>', blockquote(p('test')),
+        '<a5>', blockquote(p('hello')),
+        block3,
+        '<a6>', blockquote(p('test')),
+        '<a7>', blockquote(p('hello')),
+        block4,
+        '<a8>', blockquote(p('test')),
+        '<a9>', blockquote(p('hello')),
+        block5
+    ) as any;
+    testCases.push({
+        afterDoc: afterDoc0,
+        actionMapping: new Mapping([
+            new StepMap([afterDoc0.tag.a0, 0, getNodeSizeFor(afterDoc0, 'a0')]),
+            new StepMap([afterDoc0.tag.a1, 0, getNodeSizeFor(afterDoc0, 'a1')]),
+            new StepMap([afterDoc0.tag.a2, 0, getNodeSizeFor(afterDoc0, 'a2')]),
+            new StepMap([afterDoc0.tag.a3, 0, getNodeSizeFor(afterDoc0, 'a3')]),
+            new StepMap([afterDoc0.tag.a4, 0, getNodeSizeFor(afterDoc0, 'a4')]),
+            new StepMap([afterDoc0.tag.a5, 0, getNodeSizeFor(afterDoc0, 'a5')]),
+            new StepMap([afterDoc0.tag.a6, 0, getNodeSizeFor(afterDoc0, 'a6')]),
+            new StepMap([afterDoc0.tag.a7, 0, getNodeSizeFor(afterDoc0, 'a7')]),
+            new StepMap([afterDoc0.tag.a8, 0, getNodeSizeFor(afterDoc0, 'a8')]),
+            new StepMap([afterDoc0.tag.a9, 0, getNodeSizeFor(afterDoc0, 'a9')])
+        ]),
+        undoMapping: new Mapping([
+            new StepMap([afterDoc0.tag.a8, getNodeSizeFor(afterDoc0, 'a8') + getNodeSizeFor(afterDoc0, 'a9'), 0]),
+            new StepMap([afterDoc0.tag.a6, getNodeSizeFor(afterDoc0, 'a6') + getNodeSizeFor(afterDoc0, 'a7'), 0]),
+            new StepMap([afterDoc0.tag.a4, getNodeSizeFor(afterDoc0, 'a4') + getNodeSizeFor(afterDoc0, 'a5'), 0]),
+            new StepMap([afterDoc0.tag.a2, getNodeSizeFor(afterDoc0, 'a2') + getNodeSizeFor(afterDoc0, 'a3'), 0]),
+            new StepMap([afterDoc0.tag.a0, getNodeSizeFor(afterDoc0, 'a0') + getNodeSizeFor(afterDoc0, 'a1'), 0])
+        ])
+    });
+
+    // Test Case 1
+    const afterDoc1 = doc(
+        '<a0>', blockquote(p('test')),
+        '<a1>', blockquote(p('hello')),
+        block1,
+        block2,
+        block3,
+        '<a2>', blockquote(p('test')),
+        '<a3>', blockquote(p('hello')),
+        block4,
+        '<a4>', blockquote(p('test')),
+        '<a5>', blockquote(p('hello')),
+        block5
+    ) as any;
+    testCases.push({
+        afterDoc: afterDoc1,
+        actionMapping: new Mapping([
+            new StepMap([afterDoc1.tag.a0, 0, getNodeSizeFor(afterDoc1, 'a0')]),
+            new StepMap([afterDoc1.tag.a1, 0, getNodeSizeFor(afterDoc1, 'a1')]),
+            new StepMap([afterDoc1.tag.a2, 0, getNodeSizeFor(afterDoc1, 'a2')]),
+            new StepMap([afterDoc1.tag.a3, 0, getNodeSizeFor(afterDoc1, 'a3')]),
+            new StepMap([afterDoc1.tag.a4, 0, getNodeSizeFor(afterDoc1, 'a4')]),
+            new StepMap([afterDoc1.tag.a5, 0, getNodeSizeFor(afterDoc1, 'a5')])
+        ]),
+        undoMapping: new Mapping([
+            new StepMap([afterDoc1.tag.a4, getNodeSizeFor(afterDoc1, 'a4') + getNodeSizeFor(afterDoc1, 'a5'), 0]),
+            new StepMap([afterDoc1.tag.a2, getNodeSizeFor(afterDoc1, 'a2') + getNodeSizeFor(afterDoc1, 'a3'), 0]),
+            new StepMap([afterDoc1.tag.a0, getNodeSizeFor(afterDoc1, 'a0') + getNodeSizeFor(afterDoc1, 'a1'), 0])
+        ])
+    });
+
+    // Test Case 2
+    const afterDoc2 = doc(
+        '<a0>', blockquote(p('test')),
+        '<a1>', blockquote(p('hello')),
+        block1,
+        '<a2>', blockquote(p('test')),
+        '<a3>', blockquote(p('hello')),
+        block2,
+        block3,
+        block4,
+        '<a4>', blockquote(p('test')),
+        '<a5>', blockquote(p('hello')),
+        block5
+    ) as any;
+    testCases.push({
+        afterDoc: afterDoc2,
+        actionMapping: new Mapping([
+            new StepMap([afterDoc2.tag.a0, 0, getNodeSizeFor(afterDoc2, 'a0')]),
+            new StepMap([afterDoc2.tag.a1, 0, getNodeSizeFor(afterDoc2, 'a1')]),
+            new StepMap([afterDoc2.tag.a2, 0, getNodeSizeFor(afterDoc2, 'a2')]),
+            new StepMap([afterDoc2.tag.a3, 0, getNodeSizeFor(afterDoc2, 'a3')]),
+            new StepMap([afterDoc2.tag.a4, 0, getNodeSizeFor(afterDoc2, 'a4')]),
+            new StepMap([afterDoc2.tag.a5, 0, getNodeSizeFor(afterDoc2, 'a5')])
+        ]),
+        undoMapping: new Mapping([
+            new StepMap([afterDoc2.tag.a4, getNodeSizeFor(afterDoc2, 'a4') + getNodeSizeFor(afterDoc2, 'a5'), 0]),
+            new StepMap([afterDoc2.tag.a2, getNodeSizeFor(afterDoc2, 'a2') + getNodeSizeFor(afterDoc2, 'a3'), 0]),
+            new StepMap([afterDoc2.tag.a0, getNodeSizeFor(afterDoc2, 'a0') + getNodeSizeFor(afterDoc2, 'a1'), 0])
+        ])
+    });
+
+    // Test Case 3
+    const afterDoc3 = doc(
+        block1,
+        block2,
+        '<a0>', blockquote(p('hello')),
+        block3,
+        '<a1>', blockquote(p('hello')),
+        block4,
+        '<a2>', blockquote(p('hello')),
+        block5
+    ) as any;
+    testCases.push({
+        afterDoc: afterDoc3,
+        actionMapping: new Mapping([
+            new StepMap([afterDoc3.tag.a0, 0, getNodeSizeFor(afterDoc3, 'a0')]),
+            new StepMap([afterDoc3.tag.a1, 0, getNodeSizeFor(afterDoc3, 'a1')]),
+            new StepMap([afterDoc3.tag.a2, 0, getNodeSizeFor(afterDoc3, 'a2')])
+        ]),
+        undoMapping: new Mapping([
+            new StepMap([afterDoc3.tag.a4, getNodeSizeFor(afterDoc3, 'a2'), 0]),
+            new StepMap([afterDoc3.tag.a2, getNodeSizeFor(afterDoc3, 'a1'), 0]),
+            new StepMap([afterDoc3.tag.a0, getNodeSizeFor(afterDoc3, 'a0'), 0])
+        ])
+    });
+
+    testCases.forEach(({ afterDoc, actionMapping, undoMapping}: DecorationSetTestCase, i: number) => {
+        it(`on action (test case ${i})`, () => {
+            const expectedAfterActionDecos = getDecorations(afterDoc);
+
+            let afterActionSet = beforeDecorationSet.map(actionMapping, afterDoc);
+            assert.deepEqual(afterActionSet.find(), expectedAfterActionDecos.find());
+        });
+
+        it(`on undo (test case ${i})`, () => {
+            const afterActionSet = getDecorations(afterDoc);
+
+            let afterUndoSet = afterActionSet.map(undoMapping, beforeDoc);
+            assert.deepEqual(afterUndoSet.find(), beforeDecorationSet.find());
+        });
+
+        it(`on action and undo (test case ${i})`, () => {
+            const expectedAfterActionDecos = getDecorations(afterDoc);
+
+            // Act 1 - apply action
+            let afterActionSet = beforeDecorationSet.map(actionMapping, afterDoc);
+            assert.deepEqual(afterActionSet.find(), expectedAfterActionDecos.find());
+
+            // Act 2 - apply undo
+            let afterUndoSet = afterActionSet.map(undoMapping, beforeDoc);
+            assert.deepEqual(afterUndoSet.find(), beforeDecorationSet.find());
+        });
+    });
+});


### PR DESCRIPTION
Hello,
Our team has come across a bug with the DecorationSet map function. I've created a test suite where some of the tests do fail. I wasn't sure how to best integrate this with the existing tests, but I at least wanted to bring this to your attention in hopes that the bug could be fixed.

Our scenario is we are trying to insert multiple nodes throughout the doc in a single transaction. Then we undo the transaction. On undo, we notice the resulting decoration positions are off.  

The tests I created mimick this scenario by doing the following:
1. Start with the original doc `beforeDoc`
2. Apply a mapping `actionMapping`, representing our transaction for inserting nodes
3. Apply a mapping `undoMapping`, representing our transaction for undoing the previous action

Of the four test cases I created, only "test case 2" passes all the tests. What surprises me is that "test case 1" and "test case 2" have the same decoration positions but the difference is the placements of the inserted nodes in between decorations.
![pm-deco-test](https://github.com/ProseMirror/prosemirror-view/assets/5981876/9a86b75a-d159-4c13-907f-938b215b2b03)