### PR TITLE
fixes memory leak related to reused range

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -29,6 +29,10 @@ export const textRange = function(node: Text, from?: number, to?: number) {
   return range
 }
 
+export const clearReusedRange = function() {
+  reusedRange = null;
+}
+
 // Scans forward and backward through DOM positions equivalent to the
 // given one to see if the two are in the same place (i.e. after a
 // text node vs at the end of that text node)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {selectionToDOM, anchorInRightPlace, syncNodeSelection} from "./selection
 import {Decoration, viewDecorations, DecorationSource} from "./decoration"
 import {DOMObserver, safariShadowSelectionRange} from "./domobserver"
 import {readDOMChange} from "./domchange"
-import {DOMSelection, DOMNode, DOMSelectionRange, deepActiveElement} from "./dom"
+import {DOMSelection, DOMNode, DOMSelectionRange, deepActiveElement, clearReusedRange} from "./dom"
 import * as browser from "./browser"
 
 export {Decoration, DecorationSet, DecorationAttrs, DecorationSource} from "./decoration"
@@ -457,6 +457,7 @@ export class EditorView {
     }
     this.docView.destroy()
     ;(this as any).docView = null
+    clearReusedRange();
   }
 
   /// This is true when the view has been


### PR DESCRIPTION
Hi team 👋 , 
I create PM instance in a dialogue, so in my use case PM instance is created and destroyed quite often. I've noticed that after destroying PM, some references to DOM are still kept in memory - this is due to `reusedRange` not being cleared. 

This small change below should help to remove the memory leak caused by the above.