### PR TITLE
expose `forChild` of `DecorationSource`

### DIFF
--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -258,7 +258,7 @@ export interface DecorationSource {
   map: (mapping: Mapping, node: Node) => DecorationSource
   /// @internal
   locals(node: Node): readonly Decoration[]
-  /// @internal
+  /// Extract a DecorationSource containing decorations for the given child node at the given offset.
   forChild(offset: number, child: Node): DecorationSource
   /// @internal
   eq(other: DecorationSource): boolean


### PR DESCRIPTION
In https://github.com/guardian/prosemirror-elements we have the concept of a 'repeater' which when we repeat inner prosemirror instances passing outer decorations (see https://discuss.prosemirror.net/t/is-it-possible-to-get-hold-of-decorations-that-cover-the-range-managed-by-a-nodeview-in-that-nodeview/3544) we get various catastrophic RangeErrors.

https://github.com/guardian/prosemirror-elements/pull/349 effectively fixes by extracting the decorations relevant to the repeater to pass down to the views for them to treat as 'outer' decorations, but it does so be using the currently internal `forChild` of `DecorationSource`.