### PR TITLE
expose `forChild` of `DecorationSet`

### DIFF
--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -413,7 +413,7 @@ export class DecorationSet implements DecorationSource {
     return local.length || children.length ? new DecorationSet(local, children) : empty
   }
 
-  /// @internal
+  /// Extract a DecorationSource containing decorations for the given child node at the given offset.
   forChild(offset: number, node: Node): DecorationSet | DecorationGroup {
     if (this == empty) return this
     if (node.isLeaf) return DecorationSet.empty


### PR DESCRIPTION
Small corrective follow-up to https://github.com/ProseMirror/prosemirror-view/pull/165 since `forChild` was still marked as `internal` in `DecorationSet` (one of the implementations of `DecorationSource`) which I missed, and results in things like...
<img width="748" alt="image" src="https://github.com/ProseMirror/prosemirror-view/assets/19289579/a126325e-50a4-41b4-876e-58bac8b5572c">
