### PR TITLE
use `transformCopied` in `dragstart` handler

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -36,7 +36,7 @@ export function serializeForClipboard(view: EditorView, slice: Slice) {
   let text = view.someProp("clipboardTextSerializer", f => f(slice, view)) ||
       slice.content.textBetween(0, slice.content.size, "\n\n")
 
-  return {dom: wrap, text}
+  return {dom: wrap, text, slice}
 }
 
 // Read a slice of content from the clipboard (or drop data).

--- a/src/input.ts
+++ b/src/input.ts
@@ -674,7 +674,8 @@ handlers.dragstart = (view, _event) => {
     if (desc && desc.node.type.spec.draggable && desc != view.docView)
       node = NodeSelection.create(view.state.doc, desc.posBefore)
   }
-  let slice = (node || view.state.selection).content(), {dom, text} = serializeForClipboard(view, slice)
+  let draggedSlice = (node || view.state.selection).content()
+  let {dom, text, slice} = serializeForClipboard(view, draggedSlice)
   event.dataTransfer.clearData()
   event.dataTransfer.setData(brokenClipboardAPI ? "Text" : "text/html", dom.innerHTML)
   // See https://github.com/ProseMirror/prosemirror/issues/1156


### PR DESCRIPTION
### Description of issue
When you drag and drop content, `transformCopied` and `transformPasted` are both called, but upon dropping content `transformPasted` receives the original slice instead of the transformed slice.

`editHandlers.dragstart` currently calls `transformCopied` via the `serializeForClipboard` function, but the transformed slice isn't attached to `view.dragging`. So when `editHandlers.drop` calls `transformPasted`, it receives the original (unmodified) slice.

I would have expected `transformPasted` to receive the transformed slice returned from `transformCopied`, which is how the editor behaves with cut and paste. 

### Description of fix
Inside the `dragstart` handler, my PR grabs the transformed slice from `serializeForClipboard` so it can be attached to `view.dragging = new Dragging(...)`

