### PR TITLE
Export `DecorationGroup` so that it can be used by consumers

### DIFF
--- a/src/decoration.ts
+++ b/src/decoration.ts
@@ -482,7 +482,7 @@ const empty = DecorationSet.empty
 // An abstraction that allows the code dealing with decorations to
 // treat multiple DecorationSet objects as if it were a single object
 // with (a subset of) the same interface.
-class DecorationGroup implements DecorationSource {
+export class DecorationGroup implements DecorationSource {
   constructor(readonly members: readonly DecorationSet[]) {}
 
   map(mapping: Mapping, doc: Node) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {readDOMChange} from "./domchange"
 import {DOMSelection, DOMNode, DOMSelectionRange, deepActiveElement, clearReusedRange} from "./dom"
 import * as browser from "./browser"
 
-export {Decoration, DecorationSet, DecorationAttrs, DecorationSource} from "./decoration"
+export {Decoration, DecorationSet, DecorationAttrs, DecorationSource, DecorationGroup} from "./decoration"
 export {NodeView} from "./viewdesc"
 
 // Exported for testing


### PR DESCRIPTION
Export `DecorationGroup`, so that consuming packages can make use of its type.

### Why?
We want `DecorationGroup` to be exportd so that we can make a plugin aware that it may receive either a `DecorationSet` or a `DecorationGroup`. `DecorationGroup` can't be used as a type currently because it isn't exported from prosemirror-view.

It seemed more useful to export the class than to make an interface mirroring the class, because the interface and class would then need to be updated in tandem.

In our case, we are handing decorations from a parent editor to a nested editor controlled by [our plugin](https://github.com/guardian/prosemirror-elements/pulls). We receive decorations from the parent editor, and the plugin receives either a `DecorationGroup` or a `DecorationSet` ([see code here](https://github.com/guardian/prosemirror-elements/blob/0deb32f485e5e04768eaa6e20c8711794d160fcb/src/plugin/fieldViews/ProseMirrorFieldView.ts#L354)).  In order to find only the relevant decorations to the nested field, we access the `find` method in the case of`DecorationSet`, or access the underlyng `members` in a `DecorationGroup` and find the relevant decorations for those members.

We currently maintain [our own type declaration](https://github.com/guardian/prosemirror-elements/blob/main/src/declarations/prosemirror-view.d.ts) for `DecorationGroup` to make it possible to use in TypeScript, but we'd rather use the interface from prosemirror-view directly.



