### PR TITLE
Clear trackWrites on destroy to prevent memory leak

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -458,6 +458,7 @@ export class EditorView {
     }
     this.docView.destroy()
     ;(this as any).docView = null
+    this.trackWrites = null
     clearReusedRange();
   }
 


### PR DESCRIPTION
I did some memory profiling and came across an orphaned editor in a detached DOM node. It looks to be related to trackWrites:

![Screenshot 2024-09-10 at 12 08 13 PM](https://github.com/user-attachments/assets/375318f0-8353-44d1-ac3f-b5345b39ef4b)

This patch clears trackWrites on destroy to prevent this case.