### PR TITLE
Fix selection when Firefox creates multi range selection across svg.

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -24,6 +24,16 @@ export function selectionFromDOM(view: EditorView, origin: string | null = null)
     }
   } else {
     let anchor = view.docView.posFromDOM(domSel.anchorNode!, domSel.anchorOffset, 1)
+    if (domSel instanceof window.Selection && domSel.rangeCount > 1) {
+      let contiguous = true
+      for (let i = 0; i < domSel.rangeCount - 1; i++) {
+        if (view.posAtDOM(domSel.getRangeAt(i + 1).startContainer, 0) !== view.posAtDOM(domSel.getRangeAt(i).endContainer, 0)) {
+          contiguous = false
+          break
+        }
+      }
+      if (contiguous) anchor = view.state.selection.$anchor.pos
+    }
     if (anchor < 0) return null
     $anchor = doc.resolve(anchor)
   }


### PR DESCRIPTION
Firefox selection breaks and restarts when dragging across an `svg`.

This issue was previous report in an unanswered [thread](https://discuss.prosemirror.net/t/selection-issue-in-firefox-with-certain-dom-elements-in-node-view/1817) and a JavaScript solution was written in this [commit](https://github.com/paulfab/prosemirror-view/commit/d57834eb454292b641419154887093a76ed2adea). Rewrite that JS commit in TS.