### PR TITLE
Add MarkView.destroy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {DOMSelection, DOMNode, DOMSelectionRange, deepActiveElement, clearReused
 import * as browser from "./browser"
 
 export {Decoration, DecorationSet, DecorationAttrs, DecorationSource} from "./decoration"
-export {NodeView} from "./viewdesc"
+export {NodeView, MarkView} from "./viewdesc"
 
 // Exported for testing
 import {serializeForClipboard, parseFromClipboard} from "./clipboard"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {Slice, ResolvedPos, DOMParser, DOMSerializer, Node, Mark} from "prosemir
 
 import {scrollRectIntoView, posAtCoords, coordsAtPos, endOfTextblock, storeScrollPos,
         resetScrollPos, focusPreventScroll} from "./domcoords"
-import {docViewDesc, ViewDesc, NodeView, NodeViewDesc} from "./viewdesc"
+import {docViewDesc, ViewDesc, NodeView, NodeViewDesc, MarkView} from "./viewdesc"
 import {initInput, destroyInput, dispatchEvent, ensureListeners, clearComposition,
         InputState, doPaste, Dragging, findCompositionNode} from "./input"
 import {selectionToDOM, anchorInRightPlace, syncNodeSelection} from "./selection"
@@ -576,7 +576,7 @@ export type NodeViewConstructor = (node: Node, view: EditorView, getPos: () => n
 
 /// The function types [used](#view.EditorProps.markViews) to create
 /// mark views.
-export type MarkViewConstructor = (mark: Mark, view: EditorView, inline: boolean) => {dom: HTMLElement, contentDOM?: HTMLElement}
+export type MarkViewConstructor = (mark: Mark, view: EditorView, inline: boolean) => MarkView
 
 type NodeViewSet = {[name: string]: NodeViewConstructor | MarkViewConstructor}
 

--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -589,7 +589,7 @@ class CompositionViewDesc extends ViewDesc {
 // some cases they will be split more often than would appear
 // necessary.
 class MarkViewDesc extends ViewDesc {
-  constructor(parent: ViewDesc, readonly mark: Mark, dom: DOMNode, contentDOM: HTMLElement, readonly spec: NodeView) {
+  constructor(parent: ViewDesc, readonly mark: Mark, dom: DOMNode, contentDOM: HTMLElement, readonly spec: MarkView) {
     super(parent, [], dom, contentDOM)
   }
 

--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -630,7 +630,7 @@ class MarkViewDesc extends ViewDesc {
   }
 
   destroy() {
-    this.spec.destroy?.()
+    if (this.spec.destroy) this.spec.destroy()
     super.destroy()
   }
 }
@@ -993,7 +993,7 @@ class CustomNodeViewDesc extends NodeViewDesc {
   }
 
   destroy() {
-    this.spec.destroy?.()
+    if (this.spec.destroy) this.spec.destroy()
     super.destroy()
   }
 

--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -17,9 +17,6 @@ declare global {
 /// the behavior of a node's in-editor representation, and need to
 /// [define](#view.EditorProps.nodeViews) a custom node view.
 ///
-/// Mark views only support `dom` and `contentDOM`, and don't support
-/// any of the node view methods.
-///
 /// Objects returned as node views must conform to this interface.
 export interface NodeView {
   /// The outer DOM node that represents the document node.

--- a/test/webtest-markview.ts
+++ b/test/webtest-markview.ts
@@ -3,7 +3,7 @@ import { doc, p, strong } from "prosemirror-test-builder"
 import { tempEditor } from "./view"
 
 describe("markViews prop", () => {
-  it("can replace a node's representation", () => {
+  it("can replace a mark's representation", () => {
     let view = tempEditor({doc: doc(p("foo", strong("bar"))),
                            markViews: {strong() { return {dom: document.createElement("var")}}}})
     ist(view.dom.querySelector("var"))

--- a/test/webtest-markview.ts
+++ b/test/webtest-markview.ts
@@ -1,0 +1,46 @@
+import ist from "ist"
+import { doc, p, strong } from "prosemirror-test-builder"
+import { tempEditor } from "./view"
+
+describe("markViews prop", () => {
+  it("can replace a node's representation", () => {
+    let view = tempEditor({doc: doc(p("foo", strong("bar"))),
+                           markViews: {strong() { return {dom: document.createElement("var")}}}})
+    ist(view.dom.querySelector("var"))
+  })
+
+  it("can provide a contentDOM property", () => {
+    let view = tempEditor({
+      doc: doc(p(strong("foo"))),
+      markViews: {strong() {
+        let dom = document.createElement("var")
+        let contentDOM = document.createElement("span")
+        dom.appendChild(contentDOM)
+        return {dom, contentDOM}
+      }}
+    })
+    let span = view.dom.querySelector("span")!
+    view.dispatch(view.state.tr.insertText("a", 2))
+    ist(view.dom.querySelector("span"), span)
+    ist(span.textContent, "faoo")
+  })
+
+  it("has its destroy method called", () => {
+    let destroyed = false
+    let view = tempEditor({
+      doc: doc(p(strong("foo"))),
+      markViews: {strong() {
+        let dom = document.createElement("var")
+        return {dom, destroy: () => destroyed = true}
+      }}
+    })
+    ist(view.dom.textContent, "foo")
+    ist(!destroyed)
+    view.dispatch(view.state.tr.delete(1, 2))
+    ist(view.dom.textContent, "oo")
+    ist(!destroyed)
+    view.dispatch(view.state.tr.delete(1, 3))
+    ist(view.dom.textContent, "")
+    ist(destroyed)
+  })
+})


### PR DESCRIPTION
This PR implements the `destroy()` method for mark views, which is required for rendering mark with other UI framework like React. See also https://discuss.prosemirror.net/t/support-destroy-method-in-markview/7855