### PR TITLE
Support MarkView.ignoreMutation

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -151,8 +151,8 @@ export class DOMObserver {
     let desc = container && this.view.docView.nearestDesc(container)
     if (desc && desc.ignoreMutation({
       type: "selection",
-      target: container!.nodeType == 3 ? container!.parentNode : container
-    } as any)) {
+      target: container!.nodeType == 3 ? container!.parentNode! : container!
+    })) {
       this.setCurSelection()
       return true
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {DOMSelection, DOMNode, DOMSelectionRange, deepActiveElement, clearReused
 import * as browser from "./browser"
 
 export {Decoration, DecorationSet, DecorationAttrs, DecorationSource} from "./decoration"
-export {NodeView, MarkView} from "./viewdesc"
+export {NodeView, MarkView, ViewMutationRecord} from "./viewdesc"
 
 // Exported for testing
 import {serializeForClipboard, parseFromClipboard} from "./clipboard"

--- a/test/view.ts
+++ b/test/view.ts
@@ -48,3 +48,8 @@ export function requireFocus(pm: EditorView) {
   pm.focus()
   return pm
 }
+
+export function flush(view: EditorView) {
+  // @ts-ignore: view.domObserver is an internal API
+  view.domObserver.flush()
+}

--- a/test/webtest-composition.ts
+++ b/test/webtest-composition.ts
@@ -2,7 +2,7 @@ import {schema, eq, doc, p, em, code, strong} from "prosemirror-test-builder"
 import ist from "ist"
 import {Decoration, DecorationSet, __endComposition, EditorView} from "prosemirror-view"
 import {EditorState, Plugin} from "prosemirror-state"
-import {tempEditor, requireFocus, findTextNode} from "./view"
+import {tempEditor, requireFocus, findTextNode, flush} from "./view"
 
 function event(pm: EditorView, type: string) {
   pm.dom.dispatchEvent(new CompositionEvent(type))
@@ -29,7 +29,7 @@ function compose(pm: EditorView, start: () => Text, update: ((node: Text) => voi
     if (i < 0) node = start()
     else update[i](node!)
     let {focusNode, focusOffset} = sel
-    pm.domObserver.flush()
+    flush(pm)
 
     if (options.cancel && i == update.length - 1) {
       ist(!hasCompositionNode(pm))
@@ -43,7 +43,7 @@ function compose(pm: EditorView, start: () => Text, update: ((node: Text) => voi
   event(pm, "compositionend")
   if (options.end) {
     options.end(node!)
-    pm.domObserver.flush()
+    flush(pm)
   }
   __endComposition(pm)
   ist(!pm.composing)
@@ -274,7 +274,7 @@ describe("EditorView composition", () => {
     event(pm, "compositionstart")
     let one = findTextNode(pm.dom, "one")!
     edit(one, "!")
-    pm.domObserver.flush()
+    flush(pm)
     event(pm, "compositionend")
     one.nodeValue = "one!!"
     let L2 = pm.dom.lastChild
@@ -282,12 +282,12 @@ describe("EditorView composition", () => {
     let two = findTextNode(pm.dom, "two")!
     ist(pm.dom.lastChild, L2)
     edit(two, ".")
-    pm.domObserver.flush()
+    flush(pm)
     ist(document.getSelection()!.focusNode, two)
     ist(document.getSelection()!.focusOffset, 4)
     ist(pm.composing)
     event(pm, "compositionend")
-    pm.domObserver.flush()
+    flush(pm)
     ist(pm.state.doc, doc(p("one!!"), p("two.")), eq)
   })
 

--- a/test/webtest-domchange.ts
+++ b/test/webtest-domchange.ts
@@ -2,8 +2,7 @@ import ist from "ist"
 import {eq, doc, p, pre, h1, a, em, img as img_, br, strong, blockquote} from "prosemirror-test-builder"
 import {EditorState, TextSelection} from "prosemirror-state"
 import {Step} from "prosemirror-transform"
-import {EditorView} from "prosemirror-view"
-import {tempEditor, findTextNode} from "./view"
+import {tempEditor, findTextNode, flush} from "./view"
 
 const img = img_({src: "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="})
 
@@ -13,10 +12,6 @@ function setSel(aNode: Node, aOff: number, fNode?: Node, fOff = 0) {
   r.setStart(aNode, aOff)
   s.removeAllRanges()
   s.addRange(r)
-}
-
-function flush(view: EditorView) {
-  view.domObserver.flush()
 }
 
 describe("DOM change", () => {

--- a/test/webtest-markview.ts
+++ b/test/webtest-markview.ts
@@ -1,6 +1,7 @@
 import ist from "ist"
 import { doc, p, strong } from "prosemirror-test-builder"
-import { tempEditor } from "./view"
+import { ViewMutationRecord } from "prosemirror-view"
+import { tempEditor, flush } from "./view"
 
 describe("markViews prop", () => {
   it("can replace a mark's representation", () => {
@@ -23,6 +24,27 @@ describe("markViews prop", () => {
     view.dispatch(view.state.tr.insertText("a", 2))
     ist(view.dom.querySelector("span"), span)
     ist(span.textContent, "faoo")
+  })
+
+  it("has its ignoreMutation method called", async () => {
+    let mutation: ViewMutationRecord | undefined
+    let view = tempEditor({
+      doc: doc(p("foo", strong("bar"))),
+      markViews: {strong() { 
+        return {
+          dom: document.createElement("var"),
+          ignoreMutation: (m) => {
+            mutation = m
+            return true
+          }
+        }
+      }}
+    })
+    ist(!mutation)
+    view.dom.querySelector("var")!.classList.add("foo")
+    flush(view)
+    ist(mutation)
+    ist((mutation!.target as HTMLElement).tagName, "VAR")
   })
 
   it("has its destroy method called", () => {

--- a/test/webtest-selection.ts
+++ b/test/webtest-selection.ts
@@ -3,7 +3,7 @@ import ist from "ist"
 import {Selection, NodeSelection} from "prosemirror-state"
 import {Decoration, DecorationSet, EditorView} from "prosemirror-view"
 import {Node as PMNode} from "prosemirror-model"
-import {tempEditor, findTextNode} from "./view"
+import {tempEditor, findTextNode, flush} from "./view"
 
 const img = img_({src: "data:image/gif;base64,R0lGODlhBQAFAIABAAAAAP///yH5BAEKAAEALAAAAAAFAAUAAAIEjI+pWAA7"})
 
@@ -66,7 +66,7 @@ describe("EditorView", () => {
     function test(node: Node, offset: number, expected: number) {
       setDOMSel(node, offset)
       view.dom.focus()
-      view.domObserver.flush()
+      flush(view)
       let sel = view.state.selection
       ist(sel.head == null ? sel.from : sel.head, expected)
     }


### PR DESCRIPTION
This PR adds `MarkView.ignoreMutation()` method, similar to existing `NodeView.ignoreMutation()`. 

This is useful if users want to render and update the mark view dom element based on an extra state (like React's context) without triggering prosemirror's view update. 

---

This PR also includes some other minor updates:

- Add a new type `ViewMutationRecord`. This can reduce `as any` from ProseMirror's code and also users' code. 
- Add test for both `MarkView.ignoreMutation()` and `NodeView.ignoreMutation()`.
- Add a `flush(view)` API for easier test.

