### PR TITLE
Fix co-ordinate issue with `display: contents` nodes

### DIFF
--- a/src/domcoords.ts
+++ b/src/domcoords.ts
@@ -229,6 +229,12 @@ function posFromCaret(view: EditorView, node: Node, offset: number, coords: {top
     if (!desc) return null
     if (desc.dom.nodeType == 1 && (desc.node.isBlock && desc.parent || !desc.contentDOM)) {
       let rect = (desc.dom as HTMLElement).getBoundingClientRect()
+      if (!rect.width && !rect.height) {
+        // its possible to have a node with display:contents, yet it contains other block nodes.
+        cur = desc.dom.parentNode!
+        sawBlock = true;
+        continue;
+      }
       if (desc.node.isBlock && desc.parent) {
         // Only apply the horizontal test to the innermost block. Vertical for any parent.
         if (!sawBlock && rect.left > coords.left || rect.top > coords.top) outsideBlock = desc.posBefore


### PR DESCRIPTION
* I observed a bug with a custom table component I have implemented, based on `prosemirror-tables` . The issue arises from a conditional check in `posAtCaret` which will cause the position to use the doc.content.size when a zeroed out client rect is returned.

* This commit adds an extra conditional check which will ignore any elements that have zero width and height. This seems like a sensible solution to me but please let me know if this is unwise.


## Before this fix
A DOM setup like 

```.html
<table>
     <tr><p>CARET</p></tr>
</table>
```

```.css
table {
   display: contents
}

```

Would incorrectly return `table.posAfter` from `posAtCaret` instead of the pos of the internal `<p` node

The problematic line is here

https://github.com/ProseMirror/prosemirror-view/pull/177/files#diff-8711f18f44af6275714f55277ddd18fb124ab348b03cd4b86a4fdb253b205330R241

An element with `display: contents` will have a zerod client bounding rect. So it will always descend into this branch. 

I believe my change will handle other edge cases where an element has a zero'd bounding rects
