### PR TITLE
Remove internal ViewDesc API from type declarations

### DIFF
--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -7,7 +7,10 @@ import {Decoration, DecorationSource, WidgetConstructor, WidgetType, NodeType} f
 import {EditorView} from "./index"
 
 declare global {
-  interface Node { pmViewDesc?: ViewDesc }
+  interface Node { 
+    /// @internal
+    pmViewDesc?: ViewDesc 
+  }
 }
 
 /// A ViewMutationRecord represents a DOM


### PR DESCRIPTION
In [prosemirror-view/dist/index.d.ts](https://unpkg.com/prosemirror-view@1.38.0/dist/index.d.ts), I noticed some internal APIs:

```ts
declare global {
    interface Node {
        pmViewDesc?: ViewDesc;
    }
}

declare class ViewDesc {
  // ...
}

declare class NodeViewDesc extends ViewDesc {
  // ...
}
```

While most of these APIs are fine, `pmViewDesc` is causing issues in my automated documentation generation from `.d.ts` files. To resolve this, I propose adding `/// @internal` comment to `pmViewDesc`. This will prevent them from appearing in the generated documentation.

