### PR TITLE
Don't scroll parents of absolutely-positioned elements

### DIFF
--- a/src/domcoords.ts
+++ b/src/domcoords.ts
@@ -32,10 +32,18 @@ function clientRect(node: HTMLElement): Rect {
 export function scrollRectIntoView(view: EditorView, rect: Rect, startDOM: Node) {
   let scrollThreshold = view.someProp("scrollThreshold") || 0, scrollMargin = view.someProp("scrollMargin") || 5
   let doc = view.dom.ownerDocument
+  let ignoreNonStaticElements = false
   for (let parent: Node | null = startDOM || view.dom;; parent = parentNode(parent)) {
     if (!parent) break
     if (parent.nodeType != 1) continue
     let elt = parent as HTMLElement
+    let eltPosition = getComputedStyle(elt).position
+    if (ignoreNonStaticElements) {
+      if (eltPosition == "static") {
+        continue
+      }
+      ignoreNonStaticElements = false
+    }
     let atTop = elt == doc.body
     let bounding = atTop ? windowRect(doc) : clientRect(elt as HTMLElement)
     let moveX = 0, moveY = 0
@@ -60,7 +68,8 @@ export function scrollRectIntoView(view: EditorView, rect: Rect, startDOM: Node)
         rect = {left: rect.left - dX, top: rect.top - dY, right: rect.right - dX, bottom: rect.bottom - dY}
       }
     }
-    if (atTop || /^(fixed|sticky|absolute)$/.test(getComputedStyle(parent as HTMLElement).position)) break
+    if (atTop || /^(fixed|sticky)$/.test(eltPosition)) break
+    if (eltPosition == "absolute") ignoreNonStaticElements = true
   }
 }
 

--- a/src/domcoords.ts
+++ b/src/domcoords.ts
@@ -60,7 +60,7 @@ export function scrollRectIntoView(view: EditorView, rect: Rect, startDOM: Node)
         rect = {left: rect.left - dX, top: rect.top - dY, right: rect.right - dX, bottom: rect.bottom - dY}
       }
     }
-    if (atTop || /^(fixed|sticky)$/.test(getComputedStyle(parent as HTMLElement).position)) break
+    if (atTop || /^(fixed|sticky|absolute)$/.test(getComputedStyle(parent as HTMLElement).position)) break
   }
 }
 


### PR DESCRIPTION
FIX: Don't try to scroll absolutely-positioned elements into view by scrolling their parent elements.

I've discovered a minor bug with how `scrollToSelection` works within `prosemirror-view` as well as an easy fix for it.

### Reproduction

Here is a screen recording which shows the issue occurring. After some modifications to the CSS to re-create the layout of my use-case.


https://github.com/user-attachments/assets/2b31e615-310b-42ea-8c2f-d3367b2441ab



To reproduce this, I wrote a small script that can be pasted into a browser's console on [this example](https://prosemirror.net/examples/basic/). Though, the specific values will likely need to be modified as it depends on your viewport's size.

```js
document.querySelector('body > article:nth-child(3)').style.overflow = 'auto'
document.querySelector('body > article:nth-child(3)').style.height = '900px'
document.getElementById('editor').style.position = 'absolute'
document.getElementById('editor').style.top = '1000px'
```

The gist of this reproduction is that a parent of the editor element has absolute positioning and is a descendant of an element which is scrollable.

It is invalid to be scrolling the parent, because the editor is absolutely positioned and therefore in a different context as it's ancestor.

### Potential Solution

When recursively searching for offsets to scroll by, there already is an existing check [to stop iterating when an element has either `fixed` or `sticky` positioning](https://github.com/ProseMirror/prosemirror-view/blob/bbd0ab23e2bbdcfe8213bba003d5f4e69e6dc73f/src/domcoords.ts#L63), I believe this will also need to check for `absolute` positioning. Like so:

```diff
diff --git a/src/domcoords.ts b/src/domcoords.ts
index 5a693c3..a1586eb 100644
--- a/src/domcoords.ts
+++ b/src/domcoords.ts
@@ -60,7 +60,7 @@ export function scrollRectIntoView(view: EditorView, rect: Rect, startDOM: Node)
         rect = {left: rect.left - dX, top: rect.top - dY, right: rect.right - dX, bottom: rect.bottom - dY}
       }
     }
-    if (atTop || /^(fixed|sticky)$/.test(getComputedStyle(parent as HTMLElement).position)) break
+    if (atTop || /^(fixed|sticky|absolute)$/.test(getComputedStyle(parent as HTMLElement).position)) break
   }
 }
```

The reasoning is that, like `fixed` and `sticky` positioned elements, absolutely positioned elements break from their parent's layout (especially when positioned relative to another element with `position: relative`). Therefore, it is not valid to attempt to scroll the parent of an absolutely positioned element, since is not within the same layout context.
