### PR TITLE
fix: add ariaHidden to br hack nodes

### DIFF
--- a/src/viewdesc.ts
+++ b/src/viewdesc.ts
@@ -1383,7 +1383,10 @@ class ViewTreeUpdater {
         dom.className = "ProseMirror-separator"
         ;(dom as HTMLImageElement).alt = ""
       }
-      if (nodeName == "BR") dom.className = "ProseMirror-trailingBreak"
+      if (nodeName == "BR") {
+        dom.className = "ProseMirror-trailingBreak"
+        dom.ariaHidden = 'true'
+      }
       let hack = new TrailingHackViewDesc(this.top, [], dom, null)
       if (parent != this.top) parent.children.push(hack)
       else parent.children.splice(this.index++, 0, hack)


### PR DESCRIPTION
In the same spirit as https://github.com/ProseMirror/prosemirror-view/pull/118 this makes the BR hack node be hidden to screen readers
