### PR TITLE
When starting a composition, only delete the selection when selecting multiple lines

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -547,7 +547,7 @@ export function endComposition(view: EditorView, restarting = false) {
   if (restarting || view.docView && view.docView.dirty) {
     let sel = selectionFromDOM(view)
     if (sel && !sel.eq(view.state.selection)) view.dispatch(view.state.tr.setSelection(sel))
-    else if ((view.markCursor || restarting) && !view.state.selection.empty) view.dispatch(view.state.tr.deleteSelection())
+    else if ((view.markCursor || restarting) && view.state.selection.$from.parent !== view.state.selection.$to.parent) view.dispatch(view.state.tr.deleteSelection())
     else view.updateState(view.state)
     return true
   }


### PR DESCRIPTION
After reading this issue: https://github.com/ProseMirror/prosemirror/issues/1482. I'm sure the patch [4d2e1ba](https://github.com/ProseMirror/prosemirror-view/commit/4d2e1ba7545328313127a4ed94860b83e582a943) cause a bug to Sogou(https://shurufa.sogou.com) chinese input. It's partly the result of Sogou itself which doesn't sent "keydown" and "compositionupdate" events(https://github.com/electron/electron/issues/33386). And it's partly the result of the patch deletes the selection when starting a composition.

Bug reshow:
![reproduce](https://github.com/user-attachments/assets/0e235b54-594d-4042-8fd5-cc8dd8e64210)

Bug fixed:
![fixed](https://github.com/user-attachments/assets/30d54bf6-9cb2-4091-aeca-07b2a49aa7b5)
