### PR TITLE
Add an argument to transformPasted indicating if paste is plain text

### DIFF
--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -101,7 +101,7 @@ export function parseFromClipboard(view: EditorView, text: string, html: string 
     }
   }
 
-  view.someProp("transformPasted", f => { slice = f(slice!, view) })
+  view.someProp("transformPasted", f => { slice = f(slice!, view, plainText) })
   return slice
 }
 

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -44,7 +44,7 @@ export function parseFromClipboard(view: EditorView, text: string, html: string 
   let inCode = $context.parent.type.spec.code
   let dom: HTMLElement | undefined, slice: Slice | undefined
   if (!html && !text) return null
-  let asText = text && (plainText || inCode || !html)
+  let asText: boolean = !!text && (plainText || inCode || !html)
   if (asText) {
     view.someProp("transformPastedText", f => { text = f(text, inCode || plainText, view) })
     if (inCode) return text ? new Slice(Fragment.from(view.state.schema.text(text.replace(/\r\n?/g, "\n"))), 0, 0) : Slice.empty
@@ -101,7 +101,7 @@ export function parseFromClipboard(view: EditorView, text: string, html: string 
     }
   }
 
-  view.someProp("transformPasted", f => { slice = f(slice!, view, plainText) })
+  view.someProp("transformPasted", f => { slice = f(slice!, view, asText) })
   return slice
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -714,8 +714,9 @@ export interface EditorProps<P = any> {
   clipboardTextParser?: (this: P, text: string, $context: ResolvedPos, plain: boolean, view: EditorView) => Slice
 
   /// Can be used to transform pasted or dragged-and-dropped content
-  /// before it is applied to the document.
-  transformPasted?: (this: P, slice: Slice, view: EditorView) => Slice
+  /// before it is applied to the document. The `plain` flag will be
+  /// true when the text is pasted as plain text.
+  transformPasted?: (this: P, slice: Slice, view: EditorView, plain: boolean) => Slice
 
   /// Can be used to transform copied or cut content before it is
   /// serialized to the clipboard.

--- a/src/input.ts
+++ b/src/input.ts
@@ -718,7 +718,7 @@ editHandlers.drop = (view, _event) => {
   let $mouse = view.state.doc.resolve(eventPos.pos)
   let slice = dragging && dragging.slice
   if (slice) {
-    view.someProp("transformPasted", f => { slice = f(slice!, view) })
+    view.someProp("transformPasted", f => { slice = f(slice!, view, false) })
   } else {
     slice = parseFromClipboard(view, getText(event.dataTransfer),
                                brokenClipboardAPI ? null : event.dataTransfer.getData("text/html"), false, $mouse)


### PR DESCRIPTION
This PR introduces a new argument `plain: boolean` to the [`transformPasted`](https://prosemirror.net/docs/ref/#view.EditorProps.transformPasted)⁠ callback, indicating whether the pasted content should be treated as plain text.

The existing [`transformPastedText`](https://prosemirror.net/docs/ref/#view.EditorProps.transformPastedText) and [`clipboardTextParser`](https://prosemirror.net/docs/ref/#view.EditorProps.clipboardTextParser) also include this `plain` flag. However, these two functions have the argument `text: string`, while `transformPasted` does not. Therefore, I'm not entirely sure if the new API added in this PR aligns with the convention.

In my case, I'd want to perform different transformations depending on whether the `Shift` key is held down while pasting. While I can add a custom keydown handler myself, it would be much more convenient if ProseMirror could simply export the `plain` information.
