### PR TITLE
Fix a bug that input value disappears when using IME in Safari

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -74,7 +74,7 @@ export function selectionToDOM(view: EditorView, force = false) {
 
   view.domObserver.disconnectSelection()
 
-  if (view.cursorWrapper) {
+  if (view.cursorWrapper && !browser.safari) {
     selectCursorWrapper(view)
   } else {
     let {anchor, head} = sel, resetEditableFrom, resetEditableTo


### PR DESCRIPTION
Thank you very much for making this excellent product publicly available.

While working with ProseMirror inside a shadow DOM, I encountered an issue in Safari when using an IME environment. This pull request provides a fix for that problem.


### Steps to reproduce

1. Apply ProseMirror inside a shadow DOM
    * [example](https://github.com/usualoma/prosemirror-example/tree/main/shadow-ime-mark-text)
2. Focus the editing area
3. Enable IME
4. Apply “Bold”
5. Enter text and press Enter to confirm

### Expected result

* The entered text is reflected in the editor

### Actual result

* The entered text disappears

https://github.com/user-attachments/assets/b77bfb72-5da5-4c49-b110-12caed8564e9


### Conditions for occurrence

* This does not occur when Shadow DOM is not used.
* Does not occur in browsers other than Safari


### Patch contents

When using an IME in Safari within a shadow DOM, calling `selectCursorWrapper()` prevents subsequent input from being reflected, so I avoided calling it.

This change also affects cases where shadow DOM is not being used, but in Safari, even then, the expected result seems to be achieved without calling `selectCursorWrapper()`.