### PR TITLE
Fix a bug that trailing content disappears when using IME in Safari

### DIFF
--- a/src/domobserver.ts
+++ b/src/domobserver.ts
@@ -56,9 +56,11 @@ export class DOMObserver {
         // text node after a BR node) call the observer callback
         // before actually updating the DOM, which will cause
         // ProseMirror to miss the change (see #930)
-        if (browser.ie && browser.ie_version <= 11 && mutations.some(
+        if ((browser.ie && browser.ie_version <= 11 && mutations.some(
           m => m.type == "childList" && m.removedNodes.length ||
-               m.type == "characterData" && m.oldValue!.length > m.target.nodeValue!.length))
+               m.type == "characterData" && m.oldValue!.length > m.target.nodeValue!.length)) ||
+          (browser.safari && view.composing && mutations.some(
+            m => m.type == "characterData" && m.oldValue!.length > m.target.nodeValue!.length)))
           this.flushSoon()
         else
           this.flush()


### PR DESCRIPTION
This is similar to #184, but occurs in a slightly different situation.

While working with ProseMirror inside a shadow DOM, I encountered an issue in Safari when using an IME environment. This pull request provides a fix for that problem.


### Steps to reproduce

1. Apply ProseMirror inside a shadow DOM
    * [example](https://github.com/usualoma/prosemirror-example/tree/main/shadow-ime-append-text)
2. Move the cursor after the last img element
3. Enable IME
4. Enter text
5. Press Enter to confirm

### Expected result

* The content entered in step 4 remains.

### Actual result

* The content entered in step 4 disappears.

https://github.com/user-attachments/assets/561d160e-67c4-4522-bdd4-78cbaf749d8b


### Conditions for occurrence

* This does not occur when Shadow DOM is not used.
* Does not occur in browsers other than Safari


### Patch contents

When using an IME within a shadow DOM in Safari, calling `flush()` to insert content after the last `img` element causes content visible during input to disappear upon confirmation. Therefore, I changed it to call `flushSoon()`. I don't fully understand the situation with IE-specific code, but I suspect a similar issue occurs.

This change also affects cases not using shadow DOM, but `flushSoon()` should still be sufficient in those scenarios.