### PR TITLE
Fix missing transaction on readDOMChange

### DIFF
--- a/src/domchange.ts
+++ b/src/domchange.ts
@@ -268,6 +268,8 @@ export function readDOMChange(view: EditorView, from: number, to: number, typeOv
       let deflt = () => mkTr(view.state.tr.insertText(text, chFrom, chTo))
       if (!view.someProp("handleTextInput", f => f(view, chFrom, chTo, text, deflt)))
         view.dispatch(deflt())
+    } else {
+      view.dispatch(mkTr())
     }
   } else {
     view.dispatch(mkTr())


### PR DESCRIPTION
Here’s a clear English translation of your pull request description.

Translation

When I upgraded prosemirror-view from 1.37.0 to 1.41.0 in my application, I encountered an unexpected change. With a selection spanning multiple nodes, typing any character used to replace the selected range with the input. In the new version, the change is ignored and nothing happens.

Tracing the changes to find the cause, I discovered that the following commit introduced a case where a transaction that used to be dispatched is no longer dispatched. Applying this change locally restored the previous behavior.
https://github.com/ProseMirror/prosemirror-view/commit/7a6f6e8b8656fc6979a11a4730032e847f00cf3a#diff-310a73fb2a0b23f8c1355aab99401a86d9ae5d5b51116f2520c5302fe36b29f6L245

I tried to create a reproducible repository, but the conditions are complex and I couldn’t reproduce it in isolation. If this change is straightforward, I’d appreciate it being merged.