### PR TITLE
Fix hasFocus() for editors nested in contenteditable elements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -313,6 +313,20 @@ export class EditorView {
     }
   }
 
+  /// @internal
+  /// Returns the active element, accounting for nested contenteditable
+  /// elements. When the editor is inside another contenteditable,
+  /// activeElement may be the outer element even when the selection is
+  /// inside this editor.
+  effectiveActiveElement(): Element | null {
+    let active = this.root.activeElement
+    // If activeElement is an ancestor contenteditable that contains
+    // this.dom, treat this.dom as the effective active element.
+    if (active && active != this.dom && active.contains(this.dom))
+      return this.dom
+    return active
+  }
+
   /// Query whether the view has focus.
   hasFocus() {
     // Work around IE not handling focus correctly if resize handles are shown.
@@ -321,7 +335,7 @@ export class EditorView {
     if (browser.ie) {
       // If activeElement is within this.dom, and there are no other elements
       // setting `contenteditable` to false in between, treat it as focused.
-      let node = this.root.activeElement
+      let node = this.effectiveActiveElement()
       if (node == this.dom) return true
       if (!node || !this.dom.contains(node)) return false
       while (node && this.dom != node && this.dom.contains(node)) {
@@ -330,7 +344,7 @@ export class EditorView {
       }
       return true
     }
-    return this.root.activeElement == this.dom
+    return this.effectiveActiveElement() == this.dom
   }
 
   /// Focus the editor.

--- a/test/webtest-view.ts
+++ b/test/webtest-view.ts
@@ -119,4 +119,15 @@ describe("EditorView", () => {
     view.dispatch(view.state.tr.insertText("x"))
     ist(view, thisBinding)
   })
+
+  it("reports focus correctly when nested in contenteditable", () => {
+    let wrapper = document.createElement("div")
+    wrapper.contentEditable = "true"
+    space.appendChild(wrapper)
+    let view = new EditorView(wrapper, {state: EditorState.create({schema})})
+    view.focus()
+    ist(view.hasFocus())
+    view.destroy()
+    wrapper.remove()
+  })
 })


### PR DESCRIPTION
## Problem

When a ProseMirror editor is nested inside another element with `contenteditable="true"`, `view.hasFocus()` incorrectly returns `false` even when the editor has focus. This causes various functionality to break, including selection handling.

## Cause

When the editor is inside a contenteditable ancestor, the browser sets `document.activeElement` to the outermost contenteditable element rather than the editor's DOM element. The existing `hasFocus()` implementation compares `activeElement` directly to `this.dom`, which fails in this nested scenario.

## Solution

Added an `effectiveActiveElement()` helper method that accounts for nested contenteditable elements. When `activeElement` is an ancestor that contains `this.dom`, the helper returns `this.dom` as the effective active element. The `hasFocus()` method now uses this helper instead of directly accessing `this.root.activeElement`.

## Testing

- Added a new test case "reports focus correctly when nested in contenteditable" that verifies `hasFocus()` returns true when the editor is mounted inside a contenteditable wrapper
- Wrapped the entire test harness in a contenteditable element to validate behavior; several tests were failing before this fix, and now all pass.
